### PR TITLE
refactor: replace docker-compose with docker compose in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,16 +12,16 @@ PATH:=$(LOCAL_BIN):$(PATH)
 help: ## Display this help screen
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_-]+:.*?##/ { printf "  \033[36m%-15s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
-compose-up: ### Run docker-compose
-	docker-compose up --build -d postgres && docker-compose logs -f
+compose-up: ### Run docker compose
+	docker compose up --build -d postgres && docker compose logs -f
 .PHONY: compose-up
 
-compose-up-integration-test: ### Run docker-compose with integration test
-	docker-compose up --build --abort-on-container-exit --exit-code-from integration
+compose-up-integration-test: ### Run docker compose with integration test
+	docker compose up --build --abort-on-container-exit --exit-code-from integration
 .PHONY: compose-up-integration-test
 
-compose-down: ### Down docker-compose
-	docker-compose down --remove-orphans
+compose-down: ### Down docker compose
+	docker compose down --remove-orphans
 .PHONY: compose-down
 
 swag-v1: ### swag init


### PR DESCRIPTION
## Test
* make compose-up
* make compose-down

docker-compose works on older version
docker compose works on my older and newer version

If we find that docker-compose is required for some even older versions and we want to support that then we can add a version check to the Makefile