### PR TITLE
feat: enables /version endpoint

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,9 @@ type (
 
 	// App -.
 	App struct {
-		Name string `env-required:"false" yaml:"name" env:"APP_NAME"`
+		Name    string `env-required:"false" yaml:"name" env:"APP_NAME"`
+		Repo    string `env-required:"false" yaml:"repo" env:"APP_REPO"`
+		Version string `env-required:"false"`
 	}
 
 	// HTTP -.
@@ -42,7 +44,9 @@ func NewConfig() (*Config, error) {
 	// set defaults
 	cfg := &Config{
 		App: App{
-			Name: "console",
+			Name:    "console",
+			Repo:    "open-amt-cloud-toolkit/console",
+			Version: "DEVELOPMENT",
 		},
 		HTTP: HTTP{
 			Port:           "8181",

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,5 +1,6 @@
 app:
   name: "console"
+  repo: "open-amt-cloud-toolkit/console"
 
 http:
   port: "8181"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -24,7 +24,8 @@ var Version = "DEVELOPMENT"
 // Run creates objects via constructors.
 func Run(cfg *config.Config) {
 	log := logger.New(cfg.Log.Level)
-	log.Info("app - Run - version: " + Version)
+	cfg.App.Version = Version
+	log.Info("app - Run - version: " + cfg.App.Version)
 	// Repository
 	database, err := db.New(cfg.DB.URL, db.MaxPoolSize(cfg.DB.PoolMax))
 	if err != nil {
@@ -47,7 +48,7 @@ func Run(cfg *config.Config) {
 	defaultConfig.AllowHeaders = cfg.HTTP.AllowedHeaders
 
 	handler.Use(cors.New(defaultConfig))
-	v1.NewRouter(handler, log, *usecases)
+	v1.NewRouter(handler, log, *usecases, cfg)
 	wsv1.RegisterRoutes(handler, log, usecases.Devices)
 	httpServer := httpserver.New(handler, httpserver.Port("127.0.0.1", cfg.HTTP.Port))
 

--- a/internal/controller/http/v1/router.go
+++ b/internal/controller/http/v1/router.go
@@ -12,12 +12,15 @@ import (
 	swaggerFiles "github.com/swaggo/files"
 	ginSwagger "github.com/swaggo/gin-swagger"
 
+	"github.com/open-amt-cloud-toolkit/console/config"
 	"github.com/open-amt-cloud-toolkit/console/internal/usecase"
 	"github.com/open-amt-cloud-toolkit/console/pkg/logger"
 )
 
 //go:embed all:ui
 var content embed.FS
+
+var Config *config.Config
 
 // NewRouter -.
 // Swagger spec:
@@ -26,10 +29,12 @@ var content embed.FS
 // @version     1.0
 // @host        localhost:8181
 // @BasePath    /v1
-func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases) {
+func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases, cfg *config.Config) {
 	// Options
 	handler.Use(gin.Logger())
 	handler.Use(gin.Recovery())
+
+	Config = cfg
 	// Static files
 	// Serve static assets (js, css, images, etc.)
 	// Create subdirectory view of the embedded file system
@@ -57,6 +62,9 @@ func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases) {
 
 	// Prometheus metrics
 	handler.GET("/metrics", gin.WrapH(promhttp.Handler()))
+
+	// version info
+	handler.GET("/version", LatestReleaseHandler)
 
 	// Routers
 	h2 := handler.Group("/api/v1")

--- a/internal/controller/http/v1/version.go
+++ b/internal/controller/http/v1/version.go
@@ -1,0 +1,79 @@
+package v1
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/open-amt-cloud-toolkit/console/internal/entity/github"
+	"github.com/open-amt-cloud-toolkit/console/pkg/consoleerrors"
+)
+
+var (
+	ErrGithub        = consoleerrors.CreateConsoleError("LatestReleaseHandler")
+	ErrFailedToFetch = errors.New("repositoryError")
+)
+
+func RepositoryError(status string) error {
+	return fmt.Errorf("failed to fetch latest release: %w: %s", ErrFailedToFetch, status)
+}
+
+// FetchLatestRelease fetches the latest release information from GitHub API
+func FetchLatestRelease(c *gin.Context, repo string) (*github.Release, error) {
+	url := fmt.Sprintf("https://api.github.com/repos/%s/releases/latest", repo)
+
+	client := &http.Client{}
+
+	req2, _ := http.NewRequestWithContext(c, http.MethodGet, url, http.NoBody)
+
+	resp, err := client.Do(req2)
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, ErrGithub.Wrap("FetchLatestRelease", "http.Get", RepositoryError(resp.Status))
+	}
+
+	var release github.Release
+	if err := json.NewDecoder(resp.Body).Decode(&release); err != nil {
+		return nil, err
+	}
+
+	return &release, nil
+}
+
+// LatestReleaseHandler is the Gin handler function to check for the latest release
+func LatestReleaseHandler(c *gin.Context) {
+	repo := Config.App.Repo
+
+	release, err := FetchLatestRelease(c, repo)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{
+			"current": Config.App.Version,
+			"error":   err.Error(),
+		})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"current": Config.App.Version,
+		"latest": map[string]interface{}{
+			"tag_name":     release.TagName,
+			"name":         release.Name,
+			"body":         release.Body,
+			"prerelease":   release.Prerelease,
+			"created_at":   release.CreatedAt,
+			"published_at": release.PublishedAt,
+			"html_url":     release.HTMLURL,
+			"author":       release.Author,
+			"assets":       release.Assets,
+		},
+	})
+}

--- a/internal/entity/github/release.go
+++ b/internal/entity/github/release.go
@@ -1,0 +1,33 @@
+package github
+
+// Release represents the structure of the GitHub API response for releases.
+type Release struct {
+	URL         string  `json:"url"`
+	TagName     string  `json:"tag_name"`
+	Name        string  `json:"name"`
+	Body        string  `json:"body"`
+	Prerelease  bool    `json:"prerelease"`
+	CreatedAt   string  `json:"created_at"`
+	PublishedAt string  `json:"published_at"`
+	HTMLURL     string  `json:"html_url"`
+	AssetsURL   string  `json:"assets_url"`
+	UploadURL   string  `json:"upload_url"`
+	Author      Author  `json:"author"`
+	Assets      []Asset `json:"assets"`
+}
+
+type Author struct {
+	Login   string `json:"login"`
+	ID      int    `json:"id"`
+	URL     string `json:"url"`
+	HTMLURL string `json:"html_url"`
+}
+
+type Asset struct {
+	URL         string `json:"url"`
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	Label       string `json:"label"`
+	State       string `json:"state"`
+	ContentType string `json:"content_type"`
+}


### PR DESCRIPTION
Example response for MPS repo:

```
{
    "current": "DEVELOPMENT",
    "latest": {
        "assets": [],
        "author": {
            "login": "RosieAMT",
            "id": 150281137,
            "url": "https://api.github.com/users/RosieAMT",
            "html_url": "https://github.com/RosieAMT"
        },
        "body": "## [2.13.13](https://github.com/open-amt-cloud-toolkit/mps/compare/v2.13.12...v2.13.13) (2024-05-13)\n\n\n\n",
        "created_at": "2024-05-13T16:43:57Z",
        "html_url": "https://github.com/open-amt-cloud-toolkit/mps/releases/tag/v2.13.13",
        "name": "v2.13.13",
        "prerelease": false,
        "published_at": "2024-05-13T16:43:59Z",
        "tag_name": "v2.13.13"
    }
}
```
Will be used to evaluate if a new version of console exists.