### PR TITLE
refactor(keyring): correctly detect missing secret and trigger creation

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -61,7 +61,7 @@ func handleEncryptionKey(cfg *config.Config) {
 		return
 	}
 
-	if err.Error() != "The specified item could not be found in the keyring" {
+	if err.Error() != "secret not found in keyring" {
 		log.Fatal(err)
 
 		return


### PR DESCRIPTION
The error string changed after moving from 99designs/keyring to zalando/go-keyring. This ensures missing secrets are detected correctly and a new secret is created as expected.