### PR TITLE
fix(ci): resolve go-licenses failure by upgrading to Go 1.25.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,9 +180,16 @@ jobs:
         with:
           node-version: 22.x
 
-      - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
+      # Pin Go only for license generation
+      - name: Use Go 1.25.1 for license scan
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: ">=1.23.0"
+          go-version: "1.25.1"
+          check-latest: true
+      - name: Pin toolchain for this step
+        run: |
+          go version
+          go env -w GOTOOLCHAIN=local
 
       - name: Checkout Sample Web UI for license scan
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     networks:
       - openamtnetwork1
     volumes:
-      - pg-data:/var/lib/postgresql/data
+      - pg-data:/var/lib/postgresql
     environment:
       POSTGRES_USER: "postgresadmin"
       POSTGRES_PASSWORD: "admin123"


### PR DESCRIPTION
Also, fixes the PG_DATA path for Postgres 18. See https://github.com/docker-library/docs/pull/2582.