### PR TITLE
build: proxy settings for build and devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,33 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bullseye",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [
-		8181
-	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go install github.com/cosmtrek/air@latest"
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "name": "Go",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "image": "mcr.microsoft.com/devcontainers/go:1.25-trixie",
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8181
+    ],
+    "runArgs": [
+        "--env",
+        "HTTP_PROXY=${env:http_proxy:-}",
+        "--env",
+        "HTTPS_PROXY=${env:https_proxy:-}",
+        "--env",
+        "NO_PROXY=${env:no_proxy:-}",
+        "--env",
+        "http_proxy=${env:http_proxy:-}",
+        "--env",
+        "https_proxy=${env:https_proxy:-}",
+        "--env",
+        "no_proxy=${env:no_proxy:-}"
+    ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "go install github.com/air-verse/air@latest"
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,13 @@
 # Get version from the first argument
 version=$1
 
-docker build -t vprodemo.azurecr.io/console:v$version .
+# Set proxy environment variables if needed
+export HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+export HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}"
+export NO_PROXY="${NO_PROXY:-${no_proxy:-localhost,127.0.0.1}}"
+
+
+docker  build --build-arg HTTP_PROXY=$HTTP_PROXY --build-arg HTTPS_PROXY=$HTTPS_PROXY --build-arg NO_PROXY=$NO_PROXY -t vprodemo.azurecr.io/console:v$version .
 
 # Mark the Unix system outputs as executable
 chmod +x dist/linux/console_linux_x64


### PR DESCRIPTION
Issue #690 

  -> devcontainer and build.sh updated to include proxy settings
  -> golang version updated to 1.25 in devcontainer