### PR TITLE
build: proxy settings for build and devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/devcontainers/go:1.25-bookworm
+
+# 1. Define the arguments to accept them from devcontainer.json
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+
+# 2. Export them as environment variables
+ENV HTTP_PROXY=$HTTP_PROXY
+ENV HTTPS_PROXY=$HTTPS_PROXY
+ENV NO_PROXY=$NO_PROXY
+ENV http_proxy=$http_proxy
+ENV https_proxy=$https_proxy
+ENV no_proxy=$no_proxy
+
+# 3. Ensure sudo keeps these variables (crucial for features that use sudo)
+RUN echo 'Defaults env_keep += "HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy"' >> /etc/sudoers
+
+# 4. Prime the apt cache with proxy settings active
+RUN apt-get update

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,19 +1,55 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/go
 {
-	"name": "Go",
-	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/go:dev-1-bullseye",
-	// Features to add to the dev container. More info: https://containers.dev/features.
-	// "features": {},
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	"forwardPorts": [
-		8181
-	],
-	// Use 'postCreateCommand' to run commands after the container is created.
-	"postCreateCommand": "go install github.com/air-verse/air@v1.62.0"
-	// Configure tool-specific properties.
-	// "customizations": {},
-	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
-	// "remoteUser": "root"
+    "name": "Console Go",
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": "..",
+        "args": {
+            "HTTP_PROXY": "${localEnv:HTTP_PROXY:}",
+            "HTTPS_PROXY": "${localEnv:HTTPS_PROXY:}",
+            "NO_PROXY": "${localEnv:NO_PROXY:}",
+            "http_proxy": "${localEnv:http_proxy:}",
+            "https_proxy": "${localEnv:https_proxy:}",
+            "no_proxy": "${localEnv:no_proxy:}"
+        }
+    },
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    "forwardPorts": [
+        8181
+    ],
+    "features": {
+        "ghcr.io/devcontainers/features/docker-in-docker:2": {
+            "version": "latest",
+            "moby": true
+        },
+        "ghcr.io/devcontainers/features/node:1": {
+            "version": "lts"
+        },
+        "ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "configureZshAsDefaultShell": true,
+            "installOhMyZsh": true,
+            "upgradePackages": true
+        }
+    },
+    "containerEnv": {
+        "LOCAL_WORKSPACE_FOLDER": "${localWorkspaceFolder}",
+        "HTTP_PROXY": "${localEnv:HTTP_PROXY:}",
+        "HTTPS_PROXY": "${localEnv:HTTPS_PROXY:}",
+        "NO_PROXY": "${localEnv:NO_PROXY:}",
+        "http_proxy": "${localEnv:http_proxy:}",
+        "https_proxy": "${localEnv:https_proxy:}",
+        "no_proxy": "${localEnv:no_proxy:}"
+    },
+    // Use 'postCreateCommand' to run commands after the container is created.
+    "postCreateCommand": "sed -i 's/\\r$//' .devcontainer/post-create.sh && /bin/bash .devcontainer/post-create.sh"
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    // "remoteUser": "root"
 }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+set -e
+
+# Unset empty proxy variables
+for var in HTTP_PROXY HTTPS_PROXY NO_PROXY http_proxy https_proxy no_proxy; do
+  eval v="\${$var}"
+  if [ -z "$v" ]; then unset $var; fi
+done
+
+# Strip all trailing '/' or '\\' from proxy URLs for apt config
+strip_trailing_slash() {
+  local url="$1"
+  # Remove all trailing / or \
+  url="${url%%*(/|\\)}"
+  # Fallback for Bash < 4.0 (no extglob): use sed
+  echo "$url" | sed 's%[\\/]*$%%'
+}
+
+if [ -n "$HTTP_PROXY" ] || [ -n "$http_proxy" ] || [ -n "$HTTPS_PROXY" ] || [ -n "$https_proxy" ]; then
+  echo "Configuring apt to use proxy..."
+  sudo mkdir -p /etc/apt/apt.conf.d
+  # Remove all trailing / or \\ from proxy URLs
+  apt_http_proxy="$(strip_trailing_slash "${HTTP_PROXY:-${http_proxy:-}}")"
+  apt_https_proxy="$(strip_trailing_slash "${HTTPS_PROXY:-${https_proxy:-}}")"
+  sudo tee /etc/apt/apt.conf.d/99proxy > /dev/null <<EOF
+Acquire::http::Proxy "$apt_http_proxy";
+Acquire::https::Proxy "$apt_https_proxy";
+EOF
+fi
+
+if [ -n "$HTTP_PROXY" ] || [ -n "$http_proxy" ] || [ -n "$HTTPS_PROXY" ] || [ -n "$https_proxy" ]; then
+  echo "Configuring Docker daemon proxy..."
+  docker_http_proxy="${HTTP_PROXY:-${http_proxy:-}}"
+  docker_https_proxy="${HTTPS_PROXY:-${https_proxy:-}}"
+  docker_no_proxy="${NO_PROXY:-${no_proxy:-}}"
+  sudo mkdir -p /etc/docker
+  sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "proxies": {
+    "httpProxy": "${docker_http_proxy}",
+    "httpsProxy": "${docker_https_proxy}",
+    "noProxy": "${docker_no_proxy}"
+  }
+}
+EOF
+
+  if command -v systemctl >/dev/null 2>&1 && systemctl is-active --quiet docker; then
+    sudo systemctl restart docker
+  elif command -v service >/dev/null 2>&1 && service docker status >/dev/null 2>&1; then
+    sudo service docker restart
+  elif [ -x /usr/local/share/docker-init.sh ]; then
+    sudo pkill dockerd || true
+    sudo /usr/local/share/docker-init.sh >/tmp/docker-init.log 2>&1 || sudo /usr/local/share/docker-init.sh
+  fi
+fi
+
+echo "Installing runtime dependencies..."
+sudo apt-get update
+sudo apt-get install -y dbus dbus-x11 xdg-utils libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libnss3 libxss1 libasound2 libxtst6 xauth xvfb
+
+go install github.com/air-verse/air@latest
+go install github.com/go-delve/delve/cmd/dlv@latest

--- a/build.sh
+++ b/build.sh
@@ -6,14 +6,23 @@
 
 # Get version from the first argument
 version=$1
+# Set proxy environment variables only if they have values
+[ -n "${HTTP_PROXY:-${http_proxy:-}}" ] && export HTTP_PROXY="${HTTP_PROXY:-${http_proxy:-}}"
+[ -n "${HTTPS_PROXY:-${https_proxy:-}}" ] && export HTTPS_PROXY="${HTTPS_PROXY:-${https_proxy:-}}"
+[ -n "${NO_PROXY:-${no_proxy:-}}" ] && export NO_PROXY="${NO_PROXY:-${no_proxy:-localhost,127.0.0.1}}"
 
 # Build Docker images for each variant
 # Full build (with UI)
-docker build -t vprodemo.azurecr.io/console:v$version \
-             -t vprodemo.azurecr.io/console:latest .
+docker build --build-arg HTTP_PROXY="$HTTP_PROXY" \
+            --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
+            --build-arg NO_PROXY="$NO_PROXY" \
+            -t vprodemo.azurecr.io/console:v$version \
+            -t vprodemo.azurecr.io/console:latest .
 
 # Headless build (No UI)
-docker build --build-arg BUILD_TAGS="noui" \
+docker build --build-arg HTTP_PROXY="$HTTP_PROXY" \
+             --build-arg HTTPS_PROXY="$HTTPS_PROXY" \
+             --build-arg NO_PROXY="$NO_PROXY" --build-arg BUILD_TAGS="noui" \
              -t vprodemo.azurecr.io/console:v$version-headless \
              -t vprodemo.azurecr.io/console:latest-headless .
 


### PR DESCRIPTION
  -> devcontainer go version updated to 1.25
  -> devcontainer updated to include proxy settings
  -> build script support proxy build