### PR TITLE
fix: return empty boot source for IDER actions

### DIFF
--- a/internal/usecase/devices/power.go
+++ b/internal/usecase/devices/power.go
@@ -469,8 +469,8 @@ func (uc *UseCase) getBootSource(guid string, bootSetting *dto.BootSetting) stri
 	switch bootSetting.Action {
 	case BootActionResetToPXE, BootActionPowerOnToPXE:
 		return string(cimBoot.PXE)
-	case BootActionResetToIDERCDROM, BootActionPowerOnIDERCDROM:
-		return string(cimBoot.CD)
+	case BootActionResetToIDERCDROM, BootActionPowerOnIDERCDROM, BootActionResetToIDERFloppy:
+		return ""
 	case BootActionHTTPSBoot, BootActionPowerOnHTTPSBoot:
 		return string(cimBoot.OCRUEFIHTTPS)
 	case BootActionPBA, BootActionPowerOnPBA:

--- a/internal/usecase/devices/power_private_test.go
+++ b/internal/usecase/devices/power_private_test.go
@@ -106,8 +106,8 @@ func TestGetBootSource(t *testing.T) {
 			},
 		},
 		{
-			name: "Action 202",
-			res:  string(cimBoot.CD),
+			name: "Action 202 - IDER CDROM",
+			res:  "",
 			bootSettings: dto.BootSetting{
 				Action: 202,
 			},


### PR DESCRIPTION
<img width="653" height="145" alt="image" src="https://github.com/user-attachments/assets/13f60e4d-e6aa-44a0-9c8a-9a8aa70e180b" />

IDER boot is controlled by UseIDER and IDERBootDevice in AMT_BootSettingData, not by ChangeBootOrder.