### PR TITLE
fix: handle uppercase/lowercase UUID mismatch during authentication

### DIFF
--- a/internal/controller/tcp/cira/handler.go
+++ b/internal/controller/tcp/cira/handler.go
@@ -2,6 +2,7 @@ package cira
 
 import (
 	"context"
+	"strings"
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/apf"
 
@@ -36,8 +37,10 @@ func (h *APFHandler) DeviceID() string {
 
 // OnProtocolVersion is called when an APF_PROTOCOLVERSION message is received.
 // Extracts and stores the device UUID for later use.
+// The UUID is normalized to lowercase to ensure case-insensitive matching
+// since AMT devices send UUIDs in uppercase but users may add devices with lowercase UUIDs.
 func (h *APFHandler) OnProtocolVersion(info apf.ProtocolVersionInfo) error {
-	h.deviceID = info.UUID
+	h.deviceID = strings.ToLower(info.UUID)
 
 	h.log.Debug("APF Protocol Version - Version: %d.%d, Trigger: %d, UUID: %s",
 		info.MajorVersion, info.MinorVersion, info.TriggerReason, info.UUID)

--- a/internal/usecase/devices/repo.go
+++ b/internal/usecase/devices/repo.go
@@ -64,7 +64,7 @@ func (uc *UseCase) GetByColumn(ctx context.Context, columnName, queryValue, tena
 }
 
 func (uc *UseCase) GetByID(ctx context.Context, guid, tenantID string, includeSecrets bool) (*dto.Device, error) {
-	data, err := uc.repo.GetByID(ctx, guid, tenantID)
+	data, err := uc.repo.GetByID(ctx, strings.ToLower(guid), tenantID)
 	if err != nil {
 		return nil, ErrDatabase.Wrap("GetByID", "uc.repo.GetByID", err)
 	}
@@ -146,7 +146,7 @@ func (uc *UseCase) GetByTags(ctx context.Context, tags, method string, limit, of
 }
 
 func (uc *UseCase) Delete(ctx context.Context, guid, tenantID string) error {
-	isSuccessful, err := uc.repo.Delete(ctx, guid, tenantID)
+	isSuccessful, err := uc.repo.Delete(ctx, strings.ToLower(guid), tenantID)
 	if err != nil {
 		return ErrDatabase.Wrap("Delete", "uc.repo.Delete", err)
 	}

--- a/internal/usecase/devices/usecase.go
+++ b/internal/usecase/devices/usecase.go
@@ -78,7 +78,7 @@ func (uc *UseCase) dtoToEntity(d *dto.Device) (*entity.Device, error) {
 		ConnectionStatus: d.ConnectionStatus,
 		MPSInstance:      d.MPSInstance,
 		Hostname:         d.Hostname,
-		GUID:             d.GUID,
+		GUID:             strings.ToLower(d.GUID), // Normalize GUID to lowercase for case-insensitive matching
 		MPSUsername:      d.MPSUsername,
 		Tags:             tags,
 		TenantID:         d.TenantID,


### PR DESCRIPTION
**Summary**

Fixes #775 - CIRA authentication fails due to case-sensitive UUID comparison

**Problem**

CIRA authentication fails when a device is added with a lowercase UUID because AMT devices send their UUID in uppercase during the protocol handshake, but the database lookup performs a case-sensitive comparison.

 **To Reproduce the Issue**

1. Add a device via UI with lowercase UUID (e.g., `d4f5e6a7-b8c9-1234-5678-9abcdef01234`)
2. Configure CIRA on the AMT device
3. Observe console logs

**Result:** Authentication fails with: `Authentication failed for device 4F5E6A7-B8C9-1234-5678-9ABCDEF01234
 
**Solution**
Implemented UUID normalization to lowercase at all entry/exit points:

**After the Fix**

1. Add a device with lowercase UUID: `d4f5e6a7-b8c9-1234-5678-9abcdef01234`
2. Configure CIRA on the AMT device
3. AMT device connects

**Testing**

- Added unit tests for UUID normalization in `repo_test.go`:
  - `TestGetByID_UUIDNormalization`
  - `TestDelete_UUIDNormalization`
  - `TestUpdate_UUIDNormalization`
- Manual testing with AMT device confirmed CIRA connection succeeds