### PR TITLE
fix: resolve Memory Summary showing no data in Hardware Information (…

### DIFF
--- a/internal/usecase/devices/wsman/message.go
+++ b/internal/usecase/devices/wsman/message.go
@@ -563,13 +563,13 @@ func createMapInterfaceForHWInfo(hwResults HWResults) (interface{}, error) {
 		}, "CIM_Processor": map[string]interface{}{
 			"responses": []interface{}{hwResults.ProcessorResult.Body.PackageResponse},
 		}, "CIM_PhysicalMemory": map[string]interface{}{
-			"responses": interfaceSlice(hwResults.PhysicalMemoryResult.Body.PullResponse.MemoryItems),
+			"responses": convertPhysicalMemorySlice(hwResults.PhysicalMemoryResult.Body.PullResponse.MemoryItems),
 		},
 	}, nil
 }
 
-// interfaceSlice converts []physical.PhysicalMemory to []interface{} for consistent handling.
-func interfaceSlice(items []physical.PhysicalMemory) []interface{} {
+// convertPhysicalMemorySlice converts []physical.PhysicalMemory to []interface{} for consistent handling.
+func convertPhysicalMemorySlice(items []physical.PhysicalMemory) []interface{} {
 	if items == nil {
 		return []interface{}{}
 	}

--- a/internal/usecase/devices/wsman/message_test.go
+++ b/internal/usecase/devices/wsman/message_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/physical"
 )
 
-func TestInterfaceSlice(t *testing.T) {
+func TestConvertPhysicalMemorySlice(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -77,7 +77,7 @@ func TestInterfaceSlice(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := interfaceSlice(tc.input)
+			result := convertPhysicalMemorySlice(tc.input)
 			require.Equal(t, tc.expected, result)
 		})
 	}


### PR DESCRIPTION
…#816)

Enhanced createMapInterfaceForHWInfo function to handle physical memory slice.
Added test for convertPhysicalMemorySlice function achieving 100% coverage.