### PR TITLE
fix: derive sharedStaticIP from DHCPEnabled in profile export

### DIFF
--- a/internal/usecase/profiles/usecase.go
+++ b/internal/usecase/profiles/usecase.go
@@ -326,7 +326,7 @@ func (uc *UseCase) BuildConfigurationObject(profileName string, data *entity.Pro
 				Wired: config.Wired{
 					DHCPEnabled:    data.DHCPEnabled,
 					IPSyncEnabled:  data.IPSyncEnabled,
-					SharedStaticIP: false,
+					SharedStaticIP: !data.DHCPEnabled,
 				},
 				Wireless: config.Wireless{
 					WiFiSyncEnabled:     data.LocalWiFiSyncEnabled,

--- a/internal/usecase/profiles/usecase_test.go
+++ b/internal/usecase/profiles/usecase_test.go
@@ -942,6 +942,78 @@ func TestBuildConfigurationObject(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "static IP mode sets SharedStaticIP to true",
+			profile: &entity.Profile{
+				ProfileName:   "test-profile-static",
+				Tags:          "static",
+				DHCPEnabled:   false,
+				IPSyncEnabled: true,
+				Activation:    "acmactivate",
+				AMTPassword:   "testAMTPassword",
+				MEBXPassword:  "testMEBXPassword",
+				TLSMode:       0,
+				KVMEnabled:    true,
+				SOLEnabled:    false,
+				IDEREnabled:   false,
+				UserConsent:   "All",
+			},
+			domain: &entity.Domain{
+				ProvisioningCert:         "testCert",
+				ProvisioningCertPassword: "testCertPwd",
+			},
+			wifi: []config.WirelessProfile{},
+			expected: config.Configuration{
+				Name: "test-profile-static",
+				Tags: []string{"static"},
+				Configuration: config.RemoteManagement{
+					GeneralSettings: config.GeneralSettings{
+						SharedFQDN:              false,
+						NetworkInterfaceEnabled: 0,
+						PingResponseEnabled:     false,
+					},
+					Network: config.Network{
+						Wired: config.Wired{
+							DHCPEnabled:    false,
+							IPSyncEnabled:  true,
+							SharedStaticIP: true,
+						},
+						Wireless: config.Wireless{
+							Profiles: []config.WirelessProfile{},
+						},
+					},
+					Redirection: config.Redirection{
+						Enabled: true,
+						Services: config.Services{
+							KVM:  true,
+							SOL:  false,
+							IDER: false,
+						},
+						UserConsent: "All",
+					},
+					TLS: config.TLS{
+						MutualAuthentication: false,
+						Enabled:              false,
+						AllowNonTLS:          false,
+					},
+					EnterpriseAssistant: config.EnterpriseAssistant{
+						URL:      "http://test.com:8080",
+						Username: "username",
+						Password: "password",
+					},
+					AMTSpecific: config.AMTSpecific{
+						ControlMode:         "acmactivate",
+						AdminPassword:       "testAMTPassword",
+						MEBXPassword:        "testMEBXPassword",
+						ProvisioningCert:    "testCert",
+						ProvisioningCertPwd: "testCertPwd",
+						CIRA: config.CIRA{
+							EnvironmentDetection: []string{},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Previously, sharedStaticIP was hardcoded to false in the profile export configuration. It is now correctly derived as the inverse of DHCPEnabled, matching the UI behavior where selecting STATIC mode implies shared static IP is true.