### PR TITLE
ci(release): enable semantic prerelease flow 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,46 +9,28 @@ name: Semantic-Release CI
 
 on:
   push:
-    branches: [main, beta]
-    tags: ['v*-redfish.preview.*']
-
-permissions:
-  contents: read
+    branches: [main, beta, redfish]
 
 jobs:
   prepare:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.version-output.outputs.version }}
-      is_redfish: ${{ steps.detect-release-type.outputs.is_redfish }}
+      version: ${{ steps.semantic-release.outputs.version }}
     steps:
       - name: Checkout Console
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
-          persist-credentials: false
           fetch-depth: 0
+          persist-credentials: false
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ">=1.23.0"
 
-      - name: Detect Release Type
-        id: detect-release-type
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v*-redfish.preview.* ]]; then
-            echo "is_redfish=true" >> $GITHUB_OUTPUT
-            echo "Detected Redfish preview release"
-          else
-            echo "is_redfish=false" >> $GITHUB_OUTPUT
-            echo "Detected Semantic release"
-          fi
-
       - name: Install `@semantic-release/exec` plugin
-        if: steps.detect-release-type.outputs.is_redfish == 'false'
         run: npm install @semantic-release/exec @semantic-release/changelog
 
       - name: Semantic Release dry-run
-        if: steps.detect-release-type.outputs.is_redfish == 'false'
         id: semantic-release
         env:
           GITHUB_REF: ${{ github.head_ref || github.ref_name }}
@@ -56,82 +38,25 @@ jobs:
         run: |
           # unset GITHUB_ACTIONS
           # git checkout -b ${{ github.base_ref }} pull/${{ github.event.number }}/merge
-          npx semantic-release --dry-run --no-ci --branches main,$GITHUB_REF
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          echo "Running semantic-release dry-run for branches: main and ${GITHUB_REF_NAME}"
+          npx semantic-release --dry-run --no-ci
+
+          if [ ! -f .VERSION ]; then
+            echo "semantic-release did not generate .VERSION on branch '${GITHUB_REF_NAME}'."
+            echo "This usually means no release was calculated for this commit/branch."
+            exit 1
+          fi
+
           version=$(cat .VERSION)
           echo "version=$version" >> $GITHUB_OUTPUT
 
-      - name: Determine Redfish Version
-        if: steps.detect-release-type.outputs.is_redfish == 'true'
-        id: redfish-version
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Extract version from the tag
-          REDFISH_TAG="${GITHUB_REF#refs/tags/}"
-          echo "Building release for tag: $REDFISH_TAG"
-
-          # Validate tag format - must be v*-redfish.preview.*
-          if ! echo "$REDFISH_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+-redfish\.preview\.[0-9]+$'; then
-            echo "❌ Error: Invalid tag format: $REDFISH_TAG"
-            echo "Expected format: v<version>-redfish.preview.<iteration>"
-            echo "Example: v1.19.1-redfish.preview.1"
-            echo ""
-            echo "Note: Phase must be 'preview' (not alpha, beta, or other values)"
-            exit 1
-          fi
-          echo "✓ Tag format validated"
-
-          # Verify tag commit
-          CURRENT_COMMIT=$(git rev-parse HEAD)
-          TAG_COMMIT=$(git rev-list -n 1 "$REDFISH_TAG")
-
-          # Validate tag commit belongs to configured Redfish source branch
-          TARGET_BRANCH="${{ vars.REDFISH_SOURCE_BRANCH }}"
-          if [ -z "$TARGET_BRANCH" ]; then
-            TARGET_BRANCH="redfish"
-          fi
-          git fetch origin "$TARGET_BRANCH"
-          if ! git merge-base --is-ancestor "$TAG_COMMIT" "origin/$TARGET_BRANCH"; then
-            echo "❌ Error: Tag $REDFISH_TAG is not on branch $TARGET_BRANCH"
-            exit 1
-          fi
-          echo "✓ Verified tag commit is on $TARGET_BRANCH"
-
-          if [ "$TAG_COMMIT" != "$CURRENT_COMMIT" ]; then
-            echo "❌ Error: Tag $REDFISH_TAG does not point to checked out commit"
-            exit 1
-          fi
-          echo "✓ Verified tag commit matches current commit"
-
-          # Check if release already exists
-          RELEASE_CHECK=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-            -H "Accept: application/vnd.github.v3+json" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/tags/$REDFISH_TAG")
-          if echo "$RELEASE_CHECK" | grep -q '"id"'; then
-            echo "❌ Error: A release already exists for tag $REDFISH_TAG"
-            exit 1
-          fi
-          echo "✓ No existing release found for this tag"
-
-          VERSION="${REDFISH_TAG#v}"
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Redfish version: $VERSION"
-
-      - name: Set Version Output
-        id: version-output
-        run: |
-          if [ "${{ steps.detect-release-type.outputs.is_redfish }}" == "true" ]; then
-            echo "version=${{ steps.redfish-version.outputs.version }}" >> $GITHUB_OUTPUT
-          else
-            echo "version=${{ steps.semantic-release.outputs.version }}" >> $GITHUB_OUTPUT
-          fi
-
       - name: Version
-        run: echo "The next version is ${{ steps.version-output.outputs.version }}"
+        run: echo "The next version is ${{ steps.semantic-release.outputs.version }}"
 
       - name: Fail if version is empty
         run: |
-          if [ -z "${{ steps.version-output.outputs.version }}" ]; then
+          if [ -z "${{ steps.semantic-release.outputs.version }}" ]; then
             echo "Version output is empty. Failing the job."
             exit 1
           fi
@@ -141,17 +66,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
       - name: Checkout Console
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Check out Sample Web UI
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # master
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: device-management-toolkit/sample-web-ui
           ref: main
@@ -209,7 +135,7 @@ jobs:
         run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/darwin/console_mac_arm64_headless ./cmd/app
 
       # Cache all build artifacts in a single step
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
             dist/linux
@@ -218,28 +144,26 @@ jobs:
           key: all-platforms-${{ env.sha_short }}
 
   release:
-    permissions:
-      contents: write # for Git to git push
     runs-on: ubuntu-latest
-    needs: [prepare, build]
+    needs: build
     steps:
       - name: Harden Runner
-        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        uses: step-security/harden-runner@fa2e9d605c4eeb9fcad4c99c224cee0c6c7f3594 # v2.16.0
         with:
           egress-policy: audit
 
       - name: Checkout Console
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
 
       # Restore unified build cache
       - shell: bash
         run: |
           echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
 
-      - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+      - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: |
             dist/linux
@@ -265,7 +189,7 @@ jobs:
           go env -w GOTOOLCHAIN=local
 
       - name: Checkout Sample Web UI for license scan
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: device-management-toolkit/sample-web-ui
           ref: main
@@ -295,7 +219,6 @@ jobs:
         run: zip -r licenses.zip licenses
 
       - name: Docker Login
-        if: needs.prepare.outputs.is_redfish == 'false'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: vprodemo.azurecr.io
@@ -305,8 +228,8 @@ jobs:
 
       - name: Semantic Release
         id: semantic-release
-        if: needs.prepare.outputs.is_redfish == 'false'
         uses: cycjimmy/semantic-release-action@b1b432f13acb7768e0c8efdec416d363a57546f2 # v4.1.1
+        if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         with:
           semantic_version:
             19.0.5 # It is recommended to specify a version range
@@ -317,52 +240,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.ROSIE_TOKEN }}
 
-      - name: Package Redfish Binaries
-        if: needs.prepare.outputs.is_redfish == 'true'
-        run: |
-          # Mark binaries as executable
-          chmod +x dist/linux/console_linux_x64
-          chmod +x dist/linux/console_linux_arm64
-          chmod +x dist/darwin/console_mac_arm64
-
-          # Package binaries into compressed archives
-          tar cvfpz console_linux_x64.tar.gz dist/linux/console_linux_x64
-          tar cvfpz console_linux_arm64.tar.gz dist/linux/console_linux_arm64
-          tar cvfpz console_mac_arm64.tar.gz dist/darwin/console_mac_arm64
-
-      - name: Create Redfish Release
-        if: needs.prepare.outputs.is_redfish == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          REDFISH_TAG="${GITHUB_REF#refs/tags/}"
-          VERSION="${{ needs.prepare.outputs.version }}"
-
-          echo "Creating Redfish preview release for v$VERSION"
-
-          gh release create "$REDFISH_TAG" \
-            --title "Redfish Preview Release v$VERSION" \
-            --notes "Redfish preview release v$VERSION
-
-          This is a preview release for Redfish functionality testing.
-
-          **Binaries:**
-          - Linux x64 Console (Full)
-          - Linux ARM64 Console (Full)
-          - Windows x64 Console (Full)
-          - macOS ARM64 Console (Full)
-          - licenses.zip
-
-          **Note:** Docker images are not published for preview releases. Headless variants are only available in GA releases." \
-            --prerelease \
-            console_linux_x64.tar.gz#"Linux x64 Console (Full)" \
-            console_linux_arm64.tar.gz#"Linux ARM64 Console (Full)" \
-            dist/windows/console_windows_x64.exe#"Windows x64 Console (Full)" \
-            console_mac_arm64.tar.gz#"macOS ARM64 Console (Full)" \
-            licenses.zip#"Third-Party Licenses"
-
       - name: Check if OpenAPI files changed
-        if: needs.prepare.outputs.is_redfish == 'false'
         id: check-openapi-changes
         run: |
           git fetch origin main
@@ -373,12 +251,12 @@ jobs:
           fi
 
       - name: Generate OpenAPI specification
-        if: needs.prepare.outputs.is_redfish == 'false' && steps.semantic-release.outputs.new_release_published == 'true' && steps.check-openapi-changes.outputs.changed == 'true'
+        if: steps.semantic-release.outputs.new_release_published == 'true' && steps.check-openapi-changes.outputs.changed == 'true'
         run: |
           GIN_MODE=debug go run ./cmd/app
 
       - name: Verify OpenAPI spec was generated
-        if: needs.prepare.outputs.is_redfish == 'false'
+        if: steps.semantic-release.outputs.new_release_published == 'true' && steps.check-openapi-changes.outputs.changed == 'true'
         run: |
           if [ ! -f "doc/openapi.json" ]; then
             exit 1
@@ -386,7 +264,7 @@ jobs:
           head -20 doc/openapi.json
 
       - name: Push to SwaggerHub
-        if: needs.prepare.outputs.is_redfish == 'false' && vars.SWAGGERHUB_OWNER != '' && vars.SWAGGERHUB_API_NAME != ''
+        if: ${{ steps.semantic-release.outputs.new_release_published == 'true' && steps.check-openapi-changes.outputs.changed == 'true' && vars.SWAGGERHUB_OWNER != '' && vars.SWAGGERHUB_API_NAME != '' }}
         env:
           SWAGGERHUB_API_KEY: ${{ secrets.SWAGGERHUB_API_KEY }}
           SWAGGERHUB_OWNER: ${{ vars.SWAGGERHUB_OWNER }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,6 +6,10 @@
     {
       "name": "beta",
       "prerelease": "beta"
+    },
+    {
+      "name": "redfish",
+      "prerelease": "redfish-preview"
     }
   ],
   "plugins": [
@@ -15,6 +19,7 @@
         "releaseRules": [
           {
             "type": "chore",
+            "scope": "sync",
             "release": "patch"
           }
         ]


### PR DESCRIPTION
### Summary

- add redfish as a semantic-release prerelease branch in .releaserc.json
- trigger release workflow on pushes to redfish

### Why

- move away from manual tagging for redfish workflow testing
- use commit-driven semantic-release tags

### Release-Triggering Commits

**Feature (minor bump)**
feat(redfish): add -feature summary-

**Fix (patch bump / or next prerelease on same base)**
fix(redfish): fix -bug summary-

 **Sync from console and force a release (chore->patch in current config)**
chore(sync): merge console v.MAJOR.MINOR.PATCH into redfish

**If merge commit message is non-conventional, force a release with empty commit**
chore(sync): trigger release after console sync v.MAJOR.MINOR.PATCH

**Breaking change (major bump)**
feat(redfish)!: change -api/behavior summary-
**or add footer:**
**# BREAKING CHANGE: <what changed and migration note>**


### Expected tag behavior (examples)

Starting point: redfish branch cut from v1.19.3

feat(redfish): add initial redfish integration
→ v1.20.0-redfish-preview.1

fix(redfish): correct session cleanup
→ v1.20.0-redfish-preview.2

fix(redfish): handle timeout retry
→ v1.20.0-redfish-preview.3

chore(sync): merge console v1.21.3 into redfish
→ v1.21.4-redfish-preview.1

feat(redfish): add boot override API
→ v1.22.0-redfish-preview.1

fix(redfish): validate payload parsing
→ v1.22.0-redfish-preview.2

chore(sync): merge console v1.22.3 into redfish
→ v1.22.4-redfish-preview.1

Note: preview numeric suffix increments (.1, .2, ...) only when multiple releases occur on the same base version; it resets to .1 when base semver changes.