### PR TITLE
ci: upload Trivy SARIF as workflow artifact

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -28,13 +28,20 @@ jobs:
         with:
           image-ref: "app:${{ github.sha }}"
           format: "sarif"
-          output: "trivy-results.sarif"
+          output: "console-trivy-results.sarif"
           exit-code: "1"
           ignore-unfixed: true
           vuln-type: "os,library"
           severity: "UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL"
+      - name: Upload Trivy SARIF artifact
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        if: always()
+        with:
+          name: console-trivy-results-sarif
+          path: console-trivy-results.sarif
+          if-no-files-found: warn
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
         if: always()
         with:
-          sarif_file: "trivy-results.sarif"
+          sarif_file: "console-trivy-results.sarif"


### PR DESCRIPTION
## Summary
- upload as a workflow artifact in the Trivy scan workflow  keep existing SARIF upload to GitHub Security tab unchanged

## Why
- enables downloading the raw SARIF file from workflow runs for branch/PR troubleshooting and offline analysis

## Scope
- updates only