### PR TITLE
feat: implement GraphicalConsole endpoint support

### DIFF
--- a/redfish/internal/entity/v1/computer_system.go
+++ b/redfish/internal/entity/v1/computer_system.go
@@ -3,21 +3,48 @@ package redfish
 
 // ComputerSystem represents a Redfish Computer System entity.
 type ComputerSystem struct {
-	ID               string                          `json:"Id"`
-	Name             string                          `json:"Name"`
-	Description      string                          `json:"Description,omitempty"`
-	BiosVersion      string                          `json:"BiosVersion,omitempty"`
-	HostName         string                          `json:"HostName,omitempty"`
-	SystemType       SystemType                      `json:"SystemType"`
-	Manufacturer     string                          `json:"Manufacturer"`
-	Model            string                          `json:"Model"`
-	SerialNumber     string                          `json:"SerialNumber"`
-	PowerState       PowerState                      `json:"PowerState"`
-	Status           *Status                         `json:"Status,omitempty"`
-	MemorySummary    *ComputerSystemMemorySummary    `json:"MemorySummary,omitempty"`
-	ProcessorSummary *ComputerSystemProcessorSummary `json:"ProcessorSummary,omitempty"`
-	ODataID          string                          `json:"@odata.id"`
-	ODataType        string                          `json:"@odata.type"`
+	ID               string                              `json:"Id"`
+	Name             string                              `json:"Name"`
+	Description      string                              `json:"Description,omitempty"`
+	BiosVersion      string                              `json:"BiosVersion,omitempty"`
+	GraphicalConsole *ComputerSystemHostGraphicalConsole `json:"GraphicalConsole,omitempty"`
+	HostName         string                              `json:"HostName,omitempty"`
+	SystemType       SystemType                          `json:"SystemType"`
+	Manufacturer     string                              `json:"Manufacturer"`
+	Model            string                              `json:"Model"`
+	SerialNumber     string                              `json:"SerialNumber"`
+	PowerState       PowerState                          `json:"PowerState"`
+	Status           *Status                             `json:"Status,omitempty"`
+	MemorySummary    *ComputerSystemMemorySummary        `json:"MemorySummary,omitempty"`
+	ProcessorSummary *ComputerSystemProcessorSummary     `json:"ProcessorSummary,omitempty"`
+	ODataID          string                              `json:"@odata.id"`
+	ODataType        string                              `json:"@odata.type"`
+}
+
+// ComputerSystemHostGraphicalConsole represents graphical console (KVM) capabilities for a system.
+type ComputerSystemHostGraphicalConsole struct {
+	ConnectTypesSupported []string                               `json:"ConnectTypesSupported,omitempty"`
+	MaxConcurrentSessions *int64                                 `json:"MaxConcurrentSessions,omitempty"`
+	OEM                   *ComputerSystemHostGraphicalConsoleOEM `json:"Oem,omitempty"`
+	Port                  *int64                                 `json:"Port,omitempty"`
+	ServiceEnabled        *bool                                  `json:"ServiceEnabled,omitempty"`
+}
+
+// ComputerSystemHostGraphicalConsoleOEM represents OEM extensions for graphical console.
+type ComputerSystemHostGraphicalConsoleOEM struct {
+	Intel *ComputerSystemHostGraphicalConsoleIntel `json:"Intel,omitempty"`
+}
+
+// ComputerSystemHostGraphicalConsoleIntel represents Intel-specific graphical console extensions.
+type ComputerSystemHostGraphicalConsoleIntel struct {
+	AMT *ComputerSystemHostGraphicalConsoleAMT `json:"AMT,omitempty"`
+}
+
+// ComputerSystemHostGraphicalConsoleAMT represents Intel AMT graphical console status.
+type ComputerSystemHostGraphicalConsoleAMT struct {
+	ControlMode       string `json:"ControlMode,omitempty"`
+	KVMStatus         string `json:"KVMStatus,omitempty"`
+	UserConsentStatus string `json:"UserConsentStatus,omitempty"`
 }
 
 // Status represents the status and health of a resource.

--- a/redfish/internal/usecase/computer_system.go
+++ b/redfish/internal/usecase/computer_system.go
@@ -159,6 +159,9 @@ func (uc *ComputerSystemUseCase) GetComputerSystem(ctx context.Context, systemID
 	// Convert ProcessorSummary if present
 	processorSummary := uc.convertProcessorSummaryToGenerated(system.ProcessorSummary)
 
+	// Convert GraphicalConsole if present
+	graphicalConsole := uc.convertGraphicalConsoleToGenerated(system.GraphicalConsole)
+
 	result := generated.ComputerSystemComputerSystem{
 		OdataContext:     &odataContext,
 		OdataId:          &odataID,
@@ -167,6 +170,7 @@ func (uc *ComputerSystemUseCase) GetComputerSystem(ctx context.Context, systemID
 		Name:             system.Name,
 		Description:      descriptionUnion,
 		BiosVersion:      biosVersion,
+		GraphicalConsole: graphicalConsole,
 		HostName:         hostName,
 		Manufacturer:     manufacturer,
 		Model:            model,
@@ -229,6 +233,112 @@ func stringPtrIfNotEmpty(s string) *string {
 // SystemTypePtr creates a pointer to a ComputerSystemSystemType value.
 func SystemTypePtr(st generated.ComputerSystemSystemType) *generated.ComputerSystemSystemType {
 	return &st
+}
+
+func (uc *ComputerSystemUseCase) convertGraphicalConsoleToGenerated(console *redfishv1.ComputerSystemHostGraphicalConsole) *generated.ComputerSystemHostGraphicalConsole {
+	if console == nil {
+		return nil
+	}
+
+	connectTypes := make([]generated.ComputerSystemGraphicalConnectTypesSupported, 0, len(console.ConnectTypesSupported))
+	for _, ct := range console.ConnectTypesSupported {
+		switch ct {
+		case string(generated.ComputerSystemGraphicalConnectTypesSupportedKVMIP):
+			connectTypes = append(connectTypes, generated.ComputerSystemGraphicalConnectTypesSupportedKVMIP)
+		case string(generated.ComputerSystemGraphicalConnectTypesSupportedOEM):
+			connectTypes = append(connectTypes, generated.ComputerSystemGraphicalConnectTypesSupportedOEM)
+		}
+	}
+
+	generatedConsole := &generated.ComputerSystemHostGraphicalConsole{
+		MaxConcurrentSessions: console.MaxConcurrentSessions,
+		Port:                  console.Port,
+		ServiceEnabled:        console.ServiceEnabled,
+	}
+
+	if len(connectTypes) > 0 {
+		generatedConsole.ConnectTypesSupported = &connectTypes
+	}
+
+	if console.OEM != nil {
+		generatedConsole.Oem = uc.convertGraphicalConsoleOEMToGenerated(console.OEM)
+	}
+
+	return generatedConsole
+}
+
+func (uc *ComputerSystemUseCase) convertGraphicalConsoleOEMToGenerated(oem *redfishv1.ComputerSystemHostGraphicalConsoleOEM) *generated.ComputerSystemOemGraphicalConsole {
+	if oem == nil {
+		return nil
+	}
+
+	generatedOEM := &generated.ComputerSystemOemGraphicalConsole{}
+	if oem.Intel == nil {
+		return generatedOEM
+	}
+
+	generatedIntel := &generated.ComputerSystemOemIntelGraphicalConsole{}
+	if oem.Intel.AMT != nil {
+		generatedIntel.AMT = convertAMTGraphicalConsoleToGenerated(oem.Intel.AMT)
+	}
+
+	generatedOEM.Intel = generatedIntel
+
+	return generatedOEM
+}
+
+func convertAMTGraphicalConsoleToGenerated(amt *redfishv1.ComputerSystemHostGraphicalConsoleAMT) *generated.ComputerSystemOemIntelAMTGraphicalConsole {
+	generatedAMT := &generated.ComputerSystemOemIntelAMTGraphicalConsole{}
+	generatedAMT.ControlMode = convertControlModeToGenerated(amt.ControlMode)
+	generatedAMT.KVMStatus = convertKVMStatusToGenerated(amt.KVMStatus)
+	generatedAMT.UserConsentStatus = convertUserConsentStatusToGenerated(amt.UserConsentStatus)
+
+	return generatedAMT
+}
+
+func convertControlModeToGenerated(value string) *generated.ComputerSystemOemIntelAMTGraphicalConsole_ControlMode {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTGraphicalConsole_ControlMode{}
+
+	controlMode := generated.ComputerSystemOemIntelAMTControlMode(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTControlMode(controlMode); err != nil {
+		return nil
+	}
+
+	return wrapper
+}
+
+func convertKVMStatusToGenerated(value string) *generated.ComputerSystemOemIntelAMTGraphicalConsole_KVMStatus {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTGraphicalConsole_KVMStatus{}
+
+	kvmStatus := generated.ComputerSystemOemIntelAMTKVMStatus(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTKVMStatus(kvmStatus); err != nil {
+		return nil
+	}
+
+	return wrapper
+}
+
+func convertUserConsentStatusToGenerated(value string) *generated.ComputerSystemOemIntelAMTGraphicalConsole_UserConsentStatus {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTGraphicalConsole_UserConsentStatus{}
+
+	status := generated.ComputerSystemOemIntelAMTUserConsentStatus(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTUserConsentStatus(status); err != nil {
+		return nil
+	}
+
+	return wrapper
 }
 
 // convertToEntityResetType converts from generated reset type to entity reset type.

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -1,0 +1,153 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
+	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
+)
+
+type graphicalConsoleTestRepo struct {
+	system  *redfishv1.ComputerSystem
+	bootErr error
+}
+
+func (r *graphicalConsoleTestRepo) GetAll(_ context.Context) ([]string, error) {
+	return []string{"system-1"}, nil
+}
+
+func (r *graphicalConsoleTestRepo) GetByID(_ context.Context, _ string) (*redfishv1.ComputerSystem, error) {
+	if r.system == nil {
+		return nil, ErrSystemNotFound
+	}
+
+	s := *r.system
+
+	return &s, nil
+}
+
+func (r *graphicalConsoleTestRepo) UpdatePowerState(_ context.Context, _ string, _ redfishv1.PowerState) error {
+	return nil
+}
+
+func (r *graphicalConsoleTestRepo) GetBootSettings(_ context.Context, _ string) (*generated.ComputerSystemBoot, error) {
+	if r.bootErr != nil {
+		return nil, r.bootErr
+	}
+
+	return &generated.ComputerSystemBoot{}, nil
+}
+
+func (r *graphicalConsoleTestRepo) UpdateBootSettings(_ context.Context, _ string, _ *generated.ComputerSystemBoot) error {
+	return nil
+}
+
+func TestConvertGraphicalConsoleToGeneratedNil(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	if got := uc.convertGraphicalConsoleToGenerated(nil); got != nil {
+		t.Fatalf("expected nil GraphicalConsole, got %#v", got)
+	}
+}
+
+func TestGetComputerSystemGraphicalConsoleMapping(t *testing.T) {
+	t.Parallel()
+
+	serviceEnabled := true
+	maxSessions := int64(2)
+	port := int64(5900)
+
+	repo := &graphicalConsoleTestRepo{
+		system: &redfishv1.ComputerSystem{
+			ID:         "system-1",
+			Name:       "Test System",
+			SystemType: redfishv1.SystemTypePhysical,
+			PowerState: redfishv1.PowerStateOn,
+			GraphicalConsole: &redfishv1.ComputerSystemHostGraphicalConsole{
+				ConnectTypesSupported: []string{"KVMIP", "OEM", "INVALID"},
+				MaxConcurrentSessions: &maxSessions,
+				Port:                  &port,
+				ServiceEnabled:        &serviceEnabled,
+			},
+		},
+	}
+
+	uc := &ComputerSystemUseCase{Repo: repo}
+
+	result, err := uc.GetComputerSystem(context.Background(), "system-1")
+	if err != nil {
+		t.Fatalf("GetComputerSystem returned error: %v", err)
+	}
+
+	if result.GraphicalConsole == nil {
+		t.Fatal("expected GraphicalConsole to be present")
+	}
+
+	if result.GraphicalConsole.Port == nil || *result.GraphicalConsole.Port != 5900 {
+		t.Fatalf("expected Port=5900, got %#v", result.GraphicalConsole.Port)
+	}
+
+	if result.GraphicalConsole.ServiceEnabled == nil || !*result.GraphicalConsole.ServiceEnabled {
+		t.Fatalf("expected ServiceEnabled=true, got %#v", result.GraphicalConsole.ServiceEnabled)
+	}
+
+	if result.GraphicalConsole.MaxConcurrentSessions == nil || *result.GraphicalConsole.MaxConcurrentSessions != 2 {
+		t.Fatalf("expected MaxConcurrentSessions=2, got %#v", result.GraphicalConsole.MaxConcurrentSessions)
+	}
+
+	if result.GraphicalConsole.ConnectTypesSupported == nil {
+		t.Fatal("expected ConnectTypesSupported to be set")
+	}
+
+	got := *result.GraphicalConsole.ConnectTypesSupported
+	if len(got) != 2 {
+		t.Fatalf("expected 2 supported connect types, got %d: %#v", len(got), got)
+	}
+
+	if got[0] != generated.ComputerSystemGraphicalConnectTypesSupportedKVMIP {
+		t.Fatalf("expected first connect type KVMIP, got %q", got[0])
+	}
+
+	if got[1] != generated.ComputerSystemGraphicalConnectTypesSupportedOEM {
+		t.Fatalf("expected second connect type OEM, got %q", got[1])
+	}
+}
+
+func TestGetComputerSystemGraphicalConsoleDropsUnsupportedConnectTypes(t *testing.T) {
+	t.Parallel()
+
+	serviceEnabled := false
+
+	repo := &graphicalConsoleTestRepo{
+		system: &redfishv1.ComputerSystem{
+			ID:         "system-1",
+			Name:       "Test System",
+			SystemType: redfishv1.SystemTypePhysical,
+			PowerState: redfishv1.PowerStateOn,
+			GraphicalConsole: &redfishv1.ComputerSystemHostGraphicalConsole{
+				ConnectTypesSupported: []string{"INVALID"},
+				ServiceEnabled:        &serviceEnabled,
+			},
+		},
+		bootErr: errors.New("boot unavailable"),
+	}
+
+	uc := &ComputerSystemUseCase{Repo: repo}
+
+	result, err := uc.GetComputerSystem(context.Background(), "system-1")
+	if err != nil {
+		t.Fatalf("GetComputerSystem returned error: %v", err)
+	}
+
+	if result.GraphicalConsole == nil {
+		t.Fatal("expected GraphicalConsole to be present")
+	}
+
+	if result.GraphicalConsole.ConnectTypesSupported != nil {
+		t.Fatalf("expected unsupported connect types to be omitted, got %#v", result.GraphicalConsole.ConnectTypesSupported)
+	}
+}

--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -6,11 +6,15 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 
 	amtBoot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
 	cimBoot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/boot"
+	wsmanClient "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
+	optin "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
 
-	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	dto "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	dtov2 "github.com/device-management-toolkit/console/internal/entity/dto/v2"
 	"github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/pkg/logger"
 	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
@@ -33,6 +37,10 @@ const (
 
 	// maxSystemsList is the maximum number of systems to retrieve in a single request.
 	maxSystemsList = 100
+
+	// KVM connect type and status constants.
+	kvmConnectTypeKVMIP = "KVMIP"
+	kvmStatusActive     = "Active"
 
 	// Health state constants.
 	healthStateOK       = "OK"
@@ -874,7 +882,95 @@ func (r *WsmanComputerSystemRepo) GetByID(ctx context.Context, systemID string) 
 	// Build and return the complete ComputerSystem using CIM data and hardware info
 	system := r.buildComputerSystemFromCIMData(systemID, redfishPowerState, cimData, hwInfo)
 
+	// Fetch GraphicalConsole data best-effort, but avoid returning guessed values
+	// when feature retrieval fails.
+	_, featuresV2, err := r.usecase.GetFeatures(ctx, systemID)
+	if err != nil {
+		r.log.Warn("Failed to retrieve KVM features for GraphicalConsole", "systemID", systemID, "error", err)
+
+		return system, nil
+	}
+
+	system.GraphicalConsole = r.buildGraphicalConsole(device.UseTLS, featuresV2)
+
 	return system, nil
+}
+
+func (r *WsmanComputerSystemRepo) buildGraphicalConsole(useTLS bool, featuresV2 dtov2.Features) *redfishv1.ComputerSystemHostGraphicalConsole {
+	serviceEnabled := featuresV2.EnableKVM
+
+	var connectTypes []string
+
+	var port *int64
+
+	if featuresV2.KVMAvailable {
+		connectTypes = []string{kvmConnectTypeKVMIP}
+
+		redirectionPort := wsmanClient.RedirectionNonTLSPort
+		if useTLS {
+			redirectionPort = wsmanClient.RedirectionTLSPort
+		}
+
+		parsedPort, parseErr := strconv.ParseInt(redirectionPort, 10, 64)
+		if parseErr == nil {
+			port = &parsedPort
+		}
+	}
+
+	kvmStatus := determineKVMStatus(featuresV2.EnableKVM, featuresV2.KVMAvailable, featuresV2.UserConsent, featuresV2.OptInState)
+
+	// Build OEM extensions with Intel AMT status
+	oemExt := &redfishv1.ComputerSystemHostGraphicalConsoleOEM{
+		Intel: &redfishv1.ComputerSystemHostGraphicalConsoleIntel{
+			AMT: &redfishv1.ComputerSystemHostGraphicalConsoleAMT{
+				// Planned follow-up: query AMT_GeneralSettings from WS-Man to get actual control mode.
+				ControlMode: "ACM",
+				KVMStatus:   kvmStatus,
+				// Planned follow-up: query CIM_KVMRedirectionSAP and IPS_OptInService for actual user consent status.
+				UserConsentStatus: "NotRequired",
+			},
+		},
+	}
+
+	return &redfishv1.ComputerSystemHostGraphicalConsole{
+		ConnectTypesSupported: connectTypes,
+		OEM:                   oemExt,
+		Port:                  port,
+		ServiceEnabled:        &serviceEnabled,
+	}
+}
+
+// determineKVMStatus returns Intel AMT KVMStatus using KVM availability, enablement,
+// and user consent runtime state from IPS_OptInService.
+func determineKVMStatus(enableKVM, kvmAvailable bool, userConsent string, optInState int) string {
+	const (
+		userConsentKVM = "kvm"
+		userConsentAll = "all"
+	)
+
+	if !kvmAvailable {
+		return StateDisabled
+	}
+
+	if !enableKVM {
+		return StateDisabled
+	}
+
+	consentRequired := userConsent == userConsentKVM || userConsent == userConsentAll
+	if consentRequired {
+		switch optin.OptInState(optInState) {
+		case optin.InSession:
+			return kvmStatusActive
+		case optin.NotStarted, optin.Requested, optin.Displayed:
+			return "PendingConsent"
+		case optin.Received:
+			return StateEnabled
+		default:
+			return "Error"
+		}
+	}
+
+	return StateEnabled
 }
 
 // UpdatePowerState sends a power action command to the specified system via WSMAN.

--- a/redfish/internal/usecase/wsman_repo_test.go
+++ b/redfish/internal/usecase/wsman_repo_test.go
@@ -1,0 +1,224 @@
+package usecase
+
+import (
+	"testing"
+
+	optin "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
+
+	dtov2 "github.com/device-management-toolkit/console/internal/entity/dto/v2"
+	"github.com/device-management-toolkit/console/pkg/logger"
+	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
+)
+
+func TestDetermineKVMStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		enableKVM    bool
+		kvmAvailable bool
+		userConsent  string
+		optInState   int
+		want         string
+	}{
+		{
+			name:         "disabled when KVM not available",
+			enableKVM:    true,
+			kvmAvailable: false,
+			userConsent:  "kvm",
+			optInState:   int(optin.InSession),
+			want:         StateDisabled,
+		},
+		{
+			name:         "disabled when KVM feature off",
+			enableKVM:    false,
+			kvmAvailable: true,
+			userConsent:  "kvm",
+			optInState:   int(optin.InSession),
+			want:         StateDisabled,
+		},
+		{
+			name:         "active when consent required and in session",
+			enableKVM:    true,
+			kvmAvailable: true,
+			userConsent:  "kvm",
+			optInState:   int(optin.InSession),
+			want:         "Active",
+		},
+		{
+			name:         "pending consent when requested",
+			enableKVM:    true,
+			kvmAvailable: true,
+			userConsent:  "all",
+			optInState:   int(optin.Requested),
+			want:         "PendingConsent",
+		},
+		{
+			name:         "enabled when consent received",
+			enableKVM:    true,
+			kvmAvailable: true,
+			userConsent:  "all",
+			optInState:   int(optin.Received),
+			want:         StateEnabled,
+		},
+		{
+			name:         "error when consent required and unknown opt-in state",
+			enableKVM:    true,
+			kvmAvailable: true,
+			userConsent:  "kvm",
+			optInState:   999,
+			want:         "Error",
+		},
+		{
+			name:         "enabled when consent not required",
+			enableKVM:    true,
+			kvmAvailable: true,
+			userConsent:  "none",
+			optInState:   int(optin.NotStarted),
+			want:         StateEnabled,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := determineKVMStatus(tt.enableKVM, tt.kvmAvailable, tt.userConsent, tt.optInState)
+			if got != tt.want {
+				t.Fatalf("determineKVMStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertGraphicalConsoleOEM(t *testing.T, got *redfishv1.ComputerSystemHostGraphicalConsole, wantKVMStatus string) {
+	t.Helper()
+
+	if got.OEM == nil || got.OEM.Intel == nil || got.OEM.Intel.AMT == nil {
+		t.Fatal("OEM.Intel.AMT is nil")
+	}
+
+	amt := got.OEM.Intel.AMT
+
+	if amt.KVMStatus != wantKVMStatus {
+		t.Errorf("KVMStatus = %q, want %q", amt.KVMStatus, wantKVMStatus)
+	}
+
+	if amt.ControlMode != "ACM" {
+		t.Errorf("ControlMode = %q, want %q", amt.ControlMode, "ACM")
+	}
+
+	if amt.UserConsentStatus != "NotRequired" {
+		t.Errorf("UserConsentStatus = %q, want %q", amt.UserConsentStatus, "NotRequired")
+	}
+}
+
+func assertGraphicalConsole(t *testing.T, got *redfishv1.ComputerSystemHostGraphicalConsole, wantEnabled bool, wantConnTypes []string, wantPort int64, wantKVMStatus string) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatal("buildGraphicalConsole() returned nil")
+	}
+
+	if got.ServiceEnabled == nil || *got.ServiceEnabled != wantEnabled {
+		t.Errorf("ServiceEnabled = %v, want %v", got.ServiceEnabled, wantEnabled)
+	}
+
+	if wantConnTypes == nil {
+		if len(got.ConnectTypesSupported) != 0 {
+			t.Errorf("ConnectTypesSupported = %v, want empty", got.ConnectTypesSupported)
+		}
+	} else {
+		if len(got.ConnectTypesSupported) != len(wantConnTypes) || got.ConnectTypesSupported[0] != wantConnTypes[0] {
+			t.Errorf("ConnectTypesSupported = %v, want %v", got.ConnectTypesSupported, wantConnTypes)
+		}
+	}
+
+	if wantPort == 0 {
+		if got.Port != nil {
+			t.Errorf("Port = %v, want nil", got.Port)
+		}
+	} else {
+		if got.Port == nil || *got.Port != wantPort {
+			t.Errorf("Port = %v, want %d", got.Port, wantPort)
+		}
+	}
+
+	assertGraphicalConsoleOEM(t, got, wantKVMStatus)
+}
+
+func TestBuildGraphicalConsole(t *testing.T) {
+	t.Parallel()
+
+	repo := &WsmanComputerSystemRepo{log: logger.New("error")}
+	kvmIP := []string{kvmConnectTypeKVMIP}
+
+	tests := []struct {
+		name          string
+		useTLS        bool
+		features      dtov2.Features
+		wantEnabled   bool
+		wantConnTypes []string
+		wantPort      int64
+		wantKVMStatus string
+	}{
+		{
+			name:          "KVM not available - no connect types and no port",
+			useTLS:        false,
+			features:      dtov2.Features{EnableKVM: true, KVMAvailable: false, UserConsent: "none"},
+			wantEnabled:   true,
+			wantConnTypes: nil,
+			wantPort:      0,
+			wantKVMStatus: StateDisabled,
+		},
+		{
+			name:          "KVM available non-TLS port",
+			useTLS:        false,
+			features:      dtov2.Features{EnableKVM: true, KVMAvailable: true, UserConsent: "none"},
+			wantEnabled:   true,
+			wantConnTypes: kvmIP,
+			wantPort:      16994,
+			wantKVMStatus: StateEnabled,
+		},
+		{
+			name:          "KVM available TLS port",
+			useTLS:        true,
+			features:      dtov2.Features{EnableKVM: true, KVMAvailable: true, UserConsent: "none"},
+			wantEnabled:   true,
+			wantConnTypes: kvmIP,
+			wantPort:      16995,
+			wantKVMStatus: StateEnabled,
+		},
+		{
+			name:          "KVM disabled",
+			useTLS:        false,
+			features:      dtov2.Features{EnableKVM: false, KVMAvailable: true, UserConsent: "none"},
+			wantEnabled:   false,
+			wantConnTypes: kvmIP,
+			wantPort:      16994,
+			wantKVMStatus: StateDisabled,
+		},
+		{
+			name:          "consent required and in session - active",
+			useTLS:        false,
+			features:      dtov2.Features{EnableKVM: true, KVMAvailable: true, UserConsent: "kvm", OptInState: int(optin.InSession)},
+			wantEnabled:   true,
+			wantConnTypes: kvmIP,
+			wantPort:      16994,
+			wantKVMStatus: kvmStatusActive,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := repo.buildGraphicalConsole(tt.useTLS, tt.features)
+			assertGraphicalConsole(t, got, tt.wantEnabled, tt.wantConnTypes, tt.wantPort, tt.wantKVMStatus)
+		})
+	}
+}


### PR DESCRIPTION
Add GraphicalConsole data model and response mapping with KVM support metadata and targeted tests.

GraphicalConsole response in Computer systems :
  "GraphicalConsole": {
    "ConnectTypesSupported": [
      "KVMIP"
    ],
    "Oem": {
      "Intel": {
        "AMT": {
          "ControlMode": "ACM",
          "KVMStatus": "Enabled",
          "UserConsentStatus": "NotRequired"
        }
      }
    },
    "Port": 16994,
    "ServiceEnabled": true
  },

Note: "ControlMode" and "UserConsentStatus" are hardcoded, will implement in another PR.