### PR TITLE
fix: cert generation returns parsed cert with valid Raw field

### DIFF
--- a/internal/certificates/generate.go
+++ b/internal/certificates/generate.go
@@ -28,6 +28,10 @@ const (
 const (
 	pemTypeCertificate = "CERTIFICATE"
 	pemTypeRSAKey      = "RSA PRIVATE KEY"
+
+	// Map keys for certificate storage.
+	certField = "cert"
+	keyField  = "key"
 )
 
 // Sentinel errors for certificate operations.
@@ -58,12 +62,12 @@ func LoadCertificateFromStore(store security.Storager, name string) (*x509.Certi
 			return nil, nil, err
 		}
 
-		certPEM, ok := data["cert"]
+		certPEM, ok := data[certField]
 		if !ok {
 			return nil, nil, ErrCertFieldNotFound
 		}
 
-		keyPEM, ok := data["key"]
+		keyPEM, ok := data[keyField]
 		if !ok {
 			return nil, nil, ErrKeyFieldNotFound
 		}
@@ -85,8 +89,8 @@ func SaveCertificateToStore(store security.Storager, name string, cert *x509.Cer
 	// Try object storage first (stores cert/key as proper fields)
 	if objStore, ok := store.(ObjectStorager); ok {
 		return objStore.SetObject("certs/"+name, map[string]string{
-			"cert": certPEM,
-			"key":  keyPEM,
+			certField: certPEM,
+			keyField:  keyPEM,
 		})
 	}
 
@@ -199,7 +203,7 @@ func LoadOrGenerateRootCertificateWithVault(store security.Storager, addThumbPri
 			return cert, key, nil
 		}
 
-		log.Printf("Certificate not found in Vault: %v. Checking local files...", err)
+		log.Printf("Could not load root certificate from Vault: %v. Checking local files...", err)
 	}
 
 	// Try local files as fallback
@@ -302,10 +306,15 @@ func LoadOrGenerateWebServerCertificateWithVault(store security.Storager, rootCe
 		if err == nil {
 			log.Println("Web server certificate loaded from Vault")
 
+			// CIRA reads the cert/key from disk; make sure local files exist.
+			if saveErr := saveCertAndKeyToFiles(commonName, cert.Raw, key); saveErr != nil {
+				return nil, nil, fmt.Errorf("write web server certificate files: %w", saveErr)
+			}
+
 			return cert, key, nil
 		}
 
-		log.Printf("Web server certificate not found in Vault: %v. Checking local files...", err)
+		log.Printf("Could not load web server certificate from Vault: %v. Checking local files...", err)
 	}
 
 	// Try local files as fallback
@@ -366,6 +375,7 @@ func generateAndStoreWebServerCert(store security.Storager, rootCert CertAndKeyT
 		}
 	}
 
+	// IssueWebServerCertificate already wrote the cert/key files to disk.
 	return cert, key, nil
 }
 
@@ -455,7 +465,12 @@ func GenerateRootCertificate(addThumbPrintToName bool, commonName, country, orga
 
 	keyOut.Close()
 
-	return &template, privateKey, nil
+	parsedCert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return parsedCert, privateKey, nil
 }
 
 type CertAndKeyType struct {
@@ -534,7 +549,12 @@ func IssueWebServerCertificate(rootCert CertAndKeyType, addThumbPrintToName bool
 		return nil, nil, err
 	}
 
-	return &template, keys, nil
+	parsedCert, err := x509.ParseCertificate(certBytes)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return parsedCert, keys, nil
 }
 
 // saveCertAndKeyToFiles saves a certificate and private key to PEM files.

--- a/internal/certificates/generate_test.go
+++ b/internal/certificates/generate_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"math/big"
+	"os"
 	"testing"
 	"time"
 
@@ -197,6 +198,97 @@ func TestSaveCertificateToStore_Error(t *testing.T) {
 
 	err := SaveCertificateToStore(mockStore, "test-cert", cert, key)
 	assert.Error(t, err)
+
+	mockStore.AssertExpectations(t)
+}
+
+// setupConfigDir creates a temporary config directory and changes to its parent
+// so that functions writing to "config/" work correctly.
+// Returns a cleanup function that restores the original working directory.
+func setupConfigDir(t *testing.T) func() {
+	t.Helper()
+
+	origDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	tmpDir := t.TempDir()
+	err = os.MkdirAll(tmpDir+"/config", 0o755)
+	assert.NoError(t, err)
+
+	err = os.Chdir(tmpDir)
+	assert.NoError(t, err)
+
+	return func() {
+		_ = os.Chdir(origDir)
+	}
+}
+
+func TestGenerateRootCertificate_ReturnsParsedCert(t *testing.T) { //nolint:paralleltest // uses os.Chdir
+	cleanup := setupConfigDir(t)
+	defer cleanup()
+
+	cert, key, err := GenerateRootCertificate(false, "test-root", "US", "TestOrg", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
+	assert.NotNil(t, key)
+	assert.NotEmpty(t, cert.Raw, "cert.Raw must not be empty")
+
+	// Verify .Raw can be re-parsed (the fix we made)
+	reparsed, err := x509.ParseCertificate(cert.Raw)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-root", reparsed.Subject.CommonName)
+	assert.True(t, reparsed.IsCA)
+}
+
+func TestIssueWebServerCertificate_ReturnsParsedCert(t *testing.T) { //nolint:paralleltest // uses os.Chdir
+	cleanup := setupConfigDir(t)
+	defer cleanup()
+
+	// Generate root cert first
+	rootCert, rootKey, err := GenerateRootCertificate(false, "test-root-ca", "US", "TestOrg", false)
+	assert.NoError(t, err)
+
+	root := CertAndKeyType{Cert: rootCert, Key: rootKey}
+
+	cert, key, err := IssueWebServerCertificate(root, false, "test-server", "US", "TestOrg", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, cert)
+	assert.NotNil(t, key)
+	assert.NotEmpty(t, cert.Raw, "cert.Raw must not be empty")
+
+	// Verify .Raw can be re-parsed (the fix we made)
+	reparsed, err := x509.ParseCertificate(cert.Raw)
+	assert.NoError(t, err)
+	assert.Equal(t, "test-server", reparsed.Subject.CommonName)
+	assert.False(t, reparsed.IsCA)
+}
+
+func TestLoadOrGenerateWebServerCertificateWithVault_LoadsFromVault(t *testing.T) { //nolint:paralleltest // uses os.Chdir
+	cleanup := setupConfigDir(t)
+	defer cleanup()
+
+	cert, key := generateTestCertAndKey(t)
+	certPEM, keyPEM := certAndKeyToPEM(cert, key)
+
+	mockStore := new(MockObjectStorager)
+	mockStore.On("GetObject", "certs/webserver-test-server").Return(map[string]string{
+		"cert": certPEM,
+		"key":  keyPEM,
+	}, nil)
+
+	root := CertAndKeyType{Cert: cert, Key: key}
+
+	loadedCert, loadedKey, err := LoadOrGenerateWebServerCertificateWithVault(mockStore, root, false, "test-server", "US", "TestOrg", false)
+	assert.NoError(t, err)
+	assert.NotNil(t, loadedCert)
+	assert.NotNil(t, loadedKey)
+
+	// Verify cert files were persisted to disk
+	_, certErr := os.Stat("config/test-server_cert.pem")
+	assert.NoError(t, certErr, "cert file should exist on disk after Vault load")
+
+	_, keyErr := os.Stat("config/test-server_key.pem")
+	assert.NoError(t, keyErr, "key file should exist on disk after Vault load")
 
 	mockStore.AssertExpectations(t)
 }


### PR DESCRIPTION
* Return x509.ParseCertificate(certBytes) instead of &template
* Persist web server cert files to disk when loading from Vault
* Propagate saveCertAndKeyToFiles errors

Related to device-management-toolkit/deployment#573

Output:

```
docker logs device-management-toolkit-console-1
2026/05/15 01:52:20 Migrate: postgres is trying to connect, attempts left: 20
2026/05/15 01:52:21 Migrate: postgres is trying to connect, attempts left: 19
2026/05/15 01:52:22 Migrate: postgres is trying to connect, attempts left: 18
2026/05/15 01:52:23 Migrate: postgres is trying to connect, attempts left: 17
2026/05/15 01:52:24 Migrate: postgres is trying to connect, attempts left: 16
2026/05/15 01:52:25 Migrate: postgres is trying to connect, attempts left: 15
2026/05/15 01:52:26 Migrate: postgres is trying to connect, attempts left: 14
2026/05/15 01:52:27 Migrate: postgres is trying to connect, attempts left: 13
2026/05/15 01:52:28 Migrate: postgres is trying to connect, attempts left: 12
2026/05/15 01:52:29 Migrate: postgres is trying to connect, attempts left: 11
2026/05/15 01:52:31 Migrate: up success
2026/05/15 01:52:31 Connected to secret store at: http://vault:8200
2026/05/15 01:52:31 Could not load root certificate from Vault: secret not found at path: secret/data//certs/root. Checking local files...
2026/05/15 01:52:31 New root certificate generated
2026/05/15 01:52:31 Root certificate stored in Vault
2026/05/15 01:52:31 Could not load web server certificate from Vault: secret not found at path: secret/data//certs/webserver-10.49.76.159. Checking local files...
2026/05/15 01:52:32 New web server certificate generated
2026/05/15 01:52:32 Web server certificate stored in Vault
2026/05/15 01:52:32 Encryption key loaded from environment
{"level":"info","time":"2026-05-15T01:52:32Z","caller":"/app/cmd/app/main.go:76","message":"UI assets not embedded; skipping browser launch"}
{"level":"info","time":"2026-05-15T01:52:32Z","caller":"/app/cmd/app/main.go:34","message":"app - Run - version: DEVELOPMENT"}
{"level":"warn","time":"2026-05-15T01:52:32Z","caller":"/app/internal/controller/httpapi/ui.go:46","message":"Could not read embedded main.js: open ui/main.js: file does not exist"}
{"level":"info","time":"2026-05-15T01:52:32Z","caller":"/app/internal/controller/tcp/cira/tunnel.go:65","message":"CIRA server running on port 4433"}
{"level":"info","time":"2026-05-15T01:52:32Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:52:32 | 200 | 111.324µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"warn","time":"2026-05-15T01:52:33Z","caller":"/app/internal/controller/tcp/cira/tunnel.go:198","message":"Read error for device : remote error: tls: unknown certificate authority"}
{"level":"info","time":"2026-05-15T01:52:45Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:52:45 | 200 | 54.261µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:52:57Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:52:57 | 200 | 59.955µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:53:09Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:53:09 | 200 | 83.603µs |       127.0.0.1 | GET      \"/healthz\""}
```

After restart
* Root certificate loaded from Vault - loaded existing cert instead of regenerating
* Web server certificate loaded from Vault - same, loaded from Vault

```
docker restart device-management-toolkit-console-1
device-management-toolkit-console-1
hspe@BA38RNL00653:~/sinchana/test-issue573-deployment/deployment$ docker logs --tail 20 device-management-toolkit-console-1
{"level":"info","time":"2026-05-15T01:54:46Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:54:46 | 200 | 91.266µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:54:58Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:54:58 | 200 | 77.439µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:55:10Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:55:10 | 200 | 96.707µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:55:22Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:55:22 | 200 | 98.858µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:55:34Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:55:34 | 200 | 67.999µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:55:46Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:55:46 | 200 | 52.753µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"warn","time":"2026-05-15T01:55:55Z","caller":"/app/internal/controller/tcp/cira/tunnel.go:198","message":"Read error for device : remote error: tls: unknown certificate authority"}
{"level":"info","time":"2026-05-15T01:55:58Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:55:58 | 200 | 66.727µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"info","time":"2026-05-15T01:55:59Z","caller":"/app/internal/app/app.go:66","message":"app - Run - signal: terminated"}
2026/05/15 01:56:00 Migrate: no change
2026/05/15 01:56:00 Connected to secret store at: http://vault:8200
2026/05/15 01:56:00 Root certificate loaded from Vault
2026/05/15 01:56:00 Web server certificate loaded from Vault
{"level":"info","time":"2026-05-15T01:56:00Z","caller":"/app/cmd/app/main.go:76","message":"UI assets not embedded; skipping browser launch"}
{"level":"info","time":"2026-05-15T01:56:00Z","caller":"/app/cmd/app/main.go:34","message":"app - Run - version: DEVELOPMENT"}
2026/05/15 01:56:00 Encryption key loaded from environment
{"level":"warn","time":"2026-05-15T01:56:00Z","caller":"/app/internal/controller/httpapi/ui.go:46","message":"Could not read embedded main.js: open ui/main.js: file does not exist"}
{"level":"info","time":"2026-05-15T01:56:00Z","caller":"/app/internal/controller/tcp/cira/tunnel.go:65","message":"CIRA server running on port 4433"}
{"level":"info","time":"2026-05-15T01:56:12Z","caller":"/usr/local/go/src/fmt/print.go:263","message":"[GIN] 2026/05/15 - 01:56:12 | 200 | 146.643µs |       127.0.0.1 | GET      \"/healthz\""}
{"level":"warn","time":"2026-05-15T01:56:18Z","caller":"/app/internal/controller/tcp/cira/tunnel.go:198","message":"Read error for device : remote error: tls: unknown certificate authority"}
```