### PR TITLE
fix: bump Go version to 1.26.3 to address CVE-2026-27143

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.25.x]
+        go-version: [1.26.x]
         os: [windows-2019, windows-2022, ubuntu-22.04, ubuntu-24.04]
     steps:
       - name: Harden Runner

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: ">=1.23.0"
+          go-version: ">=1.26.0"
 
       - name: Install `@semantic-release/exec` plugin
         run: npm install @semantic-release/exec @semantic-release/changelog
@@ -91,7 +91,7 @@ jobs:
 
       - uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: ">=1.23.0"
+          go-version: ">=1.26.0"
 
       - name: Version
         run: echo "The next version is ${{ needs.prepare.outputs.version }}"
@@ -171,10 +171,10 @@ jobs:
           node-version: 22.x
 
       # Pin Go only for license generation
-      - name: Use Go 1.25.1 for license scan
+      - name: Use Go 1.26.3 for license scan
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
-          go-version: "1.25.1"
+          go-version: "1.26.3"
           check-latest: true
       - name: Pin toolchain for this step
         run: |

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/device-management-toolkit/console
 
-go 1.25.0
+go 1.26.3
 
 // replace github.com/device-management-toolkit/go-wsman-messages/v2 => ../go-wsman-messages
 


### PR DESCRIPTION
Arithmetic over induction variables in loops were not correctly checked for underflow or overflow, potentially leading to memory corruption.