### PR TITLE
feat: implement Serialconsole endpoint support

### DIFF
--- a/redfish/internal/controller/http/v1/handler/systems.go
+++ b/redfish/internal/controller/http/v1/handler/systems.go
@@ -5,7 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"regexp"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 
@@ -151,5 +153,52 @@ func (s *RedfishServer) GetRedfishV1SystemsComputerSystemId(c *gin.Context, comp
 		return
 	}
 
+	normalizeSerialConsoleURI(c, system)
+
 	c.JSON(http.StatusOK, system)
+}
+
+func normalizeSerialConsoleURI(c *gin.Context, system *generated.ComputerSystemComputerSystem) {
+	if system == nil || system.SerialConsole == nil || system.SerialConsole.WebSocket == nil || system.SerialConsole.WebSocket.ConsoleURI == nil {
+		return
+	}
+
+	consoleURI := *system.SerialConsole.WebSocket.ConsoleURI
+	if consoleURI == "" {
+		return
+	}
+
+	parsedURI, err := url.Parse(consoleURI)
+	if err != nil || parsedURI.IsAbs() {
+		return
+	}
+
+	host := c.GetHeader("X-Forwarded-Host")
+	if host == "" {
+		host = c.Request.Host
+	}
+	if host == "" {
+		return
+	}
+
+	scheme := webSocketScheme(c)
+	absoluteURI := scheme + "://" + host + consoleURI
+	system.SerialConsole.WebSocket.ConsoleURI = &absoluteURI
+}
+
+func webSocketScheme(c *gin.Context) string {
+	forwardedProto := strings.ToLower(strings.TrimSpace(c.GetHeader("X-Forwarded-Proto")))
+	if forwardedProto == "https" {
+		return "wss"
+	}
+
+	if forwardedProto == "http" {
+		return "ws"
+	}
+
+	if c.Request.TLS != nil {
+		return "wss"
+	}
+
+	return "ws"
 }

--- a/redfish/internal/controller/http/v1/handler/systems_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_test.go
@@ -254,6 +254,54 @@ func validateSingleSystemResponseTest(t *testing.T, w *httptest.ResponseRecorder
 	validateSystemsCollectionResponse(t, w, 1, []string{fmt.Sprintf("%s/%s", systemsEndpointTest, testUUID1)})
 }
 
+func TestGetRedfishV1SystemsComputerSystemId_AbsoluteSerialConsoleURI(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	serviceEnabled := true
+	interactive := true
+	maxSessions := int64(1)
+	consoleURI := "/relay/webrelay.ashx?host=" + testUUID1 + "&mode=sol"
+
+	repo.AddSystem(testUUID1, &redfishv1.ComputerSystem{
+		ID:           testUUID1,
+		Name:         "Test System",
+		Manufacturer: "Test Manufacturer",
+		Model:        "Test Model",
+		SerialNumber: "SN123456",
+		PowerState:   redfishv1.PowerStateOn,
+		SerialConsole: &redfishv1.ComputerSystemHostSerialConsole{
+			MaxConcurrentSessions: &maxSessions,
+			WebSocket: &redfishv1.ComputerSystemHostWebSocketConsole{
+				ConsoleURI:     &consoleURI,
+				Interactive:    &interactive,
+				ServiceEnabled: &serviceEnabled,
+			},
+		},
+	})
+
+	server := &RedfishServer{
+		ComputerSystemUC: &usecase.ComputerSystemUseCase{Repo: repo},
+	}
+
+	router := setupSystemByIDTestRouter(server)
+	req := httptest.NewRequest(http.MethodGet, "/redfish/v1/Systems/"+testUUID1, http.NoBody)
+	req.Host = "console.example.com"
+	req.Header.Set("X-Forwarded-Proto", "https")
+	w := httptest.NewRecorder()
+
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var response generated.ComputerSystemComputerSystem
+	unmarshalJSONResponseTest(t, w, &response)
+
+	if assert.NotNil(t, response.SerialConsole) && assert.NotNil(t, response.SerialConsole.WebSocket) && assert.NotNil(t, response.SerialConsole.WebSocket.ConsoleURI) {
+		assert.Equal(t, "wss://console.example.com/relay/webrelay.ashx?host="+testUUID1+"&mode=sol", *response.SerialConsole.WebSocket.ConsoleURI)
+	}
+}
+
 func validateLargeCollectionResponseTest(t *testing.T, w *httptest.ResponseRecorder, _ struct{}) {
 	t.Helper()
 

--- a/redfish/internal/entity/v1/computer_system.go
+++ b/redfish/internal/entity/v1/computer_system.go
@@ -8,6 +8,7 @@ type ComputerSystem struct {
 	Description      string                              `json:"Description,omitempty"`
 	BiosVersion      string                              `json:"BiosVersion,omitempty"`
 	GraphicalConsole *ComputerSystemHostGraphicalConsole `json:"GraphicalConsole,omitempty"`
+	SerialConsole    *ComputerSystemHostSerialConsole    `json:"SerialConsole,omitempty"`
 	HostName         string                              `json:"HostName,omitempty"`
 	SystemType       SystemType                          `json:"SystemType"`
 	Manufacturer     string                              `json:"Manufacturer"`
@@ -44,6 +45,37 @@ type ComputerSystemHostGraphicalConsoleIntel struct {
 type ComputerSystemHostGraphicalConsoleAMT struct {
 	ControlMode       string `json:"ControlMode,omitempty"`
 	KVMStatus         string `json:"KVMStatus,omitempty"`
+	UserConsentStatus string `json:"UserConsentStatus,omitempty"`
+}
+
+// ComputerSystemHostSerialConsole represents serial console (SOL) capabilities for a system.
+type ComputerSystemHostSerialConsole struct {
+	MaxConcurrentSessions *int64                              `json:"MaxConcurrentSessions,omitempty"`
+	OEM                   *ComputerSystemHostSerialConsoleOEM `json:"Oem,omitempty"`
+	WebSocket             *ComputerSystemHostWebSocketConsole `json:"WebSocket,omitempty"`
+}
+
+// ComputerSystemHostWebSocketConsole represents WebSocket settings for SOL.
+type ComputerSystemHostWebSocketConsole struct {
+	ConsoleURI     *string `json:"ConsoleURI,omitempty"`
+	Interactive    *bool   `json:"Interactive,omitempty"`
+	ServiceEnabled *bool   `json:"ServiceEnabled,omitempty"`
+}
+
+// ComputerSystemHostSerialConsoleOEM represents OEM extensions for serial console.
+type ComputerSystemHostSerialConsoleOEM struct {
+	Intel *ComputerSystemHostSerialConsoleIntel `json:"Intel,omitempty"`
+}
+
+// ComputerSystemHostSerialConsoleIntel represents Intel-specific serial console extensions.
+type ComputerSystemHostSerialConsoleIntel struct {
+	AMT *ComputerSystemHostSerialConsoleAMT `json:"AMT,omitempty"`
+}
+
+// ComputerSystemHostSerialConsoleAMT represents Intel AMT serial console status.
+type ComputerSystemHostSerialConsoleAMT struct {
+	ControlMode       string `json:"ControlMode,omitempty"`
+	SOLStatus         string `json:"SOLStatus,omitempty"`
 	UserConsentStatus string `json:"UserConsentStatus,omitempty"`
 }
 

--- a/redfish/internal/usecase/computer_system.go
+++ b/redfish/internal/usecase/computer_system.go
@@ -162,6 +162,9 @@ func (uc *ComputerSystemUseCase) GetComputerSystem(ctx context.Context, systemID
 	// Convert GraphicalConsole if present
 	graphicalConsole := uc.convertGraphicalConsoleToGenerated(system.GraphicalConsole)
 
+	// Convert SerialConsole if present
+	serialConsole := uc.convertSerialConsoleToGenerated(system.SerialConsole)
+
 	result := generated.ComputerSystemComputerSystem{
 		OdataContext:     &odataContext,
 		OdataId:          &odataID,
@@ -171,6 +174,7 @@ func (uc *ComputerSystemUseCase) GetComputerSystem(ctx context.Context, systemID
 		Description:      descriptionUnion,
 		BiosVersion:      biosVersion,
 		GraphicalConsole: graphicalConsole,
+		SerialConsole:    serialConsole,
 		HostName:         hostName,
 		Manufacturer:     manufacturer,
 		Model:            model,
@@ -332,6 +336,104 @@ func convertUserConsentStatusToGenerated(value string) *generated.ComputerSystem
 	}
 
 	wrapper := &generated.ComputerSystemOemIntelAMTGraphicalConsole_UserConsentStatus{}
+
+	status := generated.ComputerSystemOemIntelAMTUserConsentStatus(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTUserConsentStatus(status); err != nil {
+		return nil
+	}
+
+	return wrapper
+}
+
+func (uc *ComputerSystemUseCase) convertSerialConsoleToGenerated(console *redfishv1.ComputerSystemHostSerialConsole) *generated.ComputerSystemHostSerialConsole {
+	if console == nil {
+		return nil
+	}
+
+	generatedConsole := &generated.ComputerSystemHostSerialConsole{
+		MaxConcurrentSessions: console.MaxConcurrentSessions,
+	}
+
+	if console.WebSocket != nil {
+		generatedConsole.WebSocket = &generated.ComputerSystemWebSocketConsole{
+			ConsoleURI:     console.WebSocket.ConsoleURI,
+			Interactive:    console.WebSocket.Interactive,
+			ServiceEnabled: console.WebSocket.ServiceEnabled,
+		}
+	}
+
+	if console.OEM != nil {
+		generatedConsole.Oem = uc.convertSerialConsoleOEMToGenerated(console.OEM)
+	}
+
+	return generatedConsole
+}
+
+func (uc *ComputerSystemUseCase) convertSerialConsoleOEMToGenerated(oem *redfishv1.ComputerSystemHostSerialConsoleOEM) *generated.ComputerSystemOemSerialConsole {
+	if oem == nil {
+		return nil
+	}
+
+	generatedOEM := &generated.ComputerSystemOemSerialConsole{}
+	if oem.Intel == nil {
+		return generatedOEM
+	}
+
+	generatedIntel := &generated.ComputerSystemOemIntelSerialConsole{}
+	if oem.Intel.AMT != nil {
+		generatedIntel.AMT = convertAMTSerialConsoleToGenerated(oem.Intel.AMT)
+	}
+
+	generatedOEM.Intel = generatedIntel
+
+	return generatedOEM
+}
+
+func convertAMTSerialConsoleToGenerated(amt *redfishv1.ComputerSystemHostSerialConsoleAMT) *generated.ComputerSystemOemIntelAMTSerialConsole {
+	generatedAMT := &generated.ComputerSystemOemIntelAMTSerialConsole{}
+	generatedAMT.ControlMode = convertSerialControlModeToGenerated(amt.ControlMode)
+	generatedAMT.SOLStatus = convertSOLStatusToGenerated(amt.SOLStatus)
+	generatedAMT.UserConsentStatus = convertSerialUserConsentStatusToGenerated(amt.UserConsentStatus)
+
+	return generatedAMT
+}
+
+func convertSerialControlModeToGenerated(value string) *generated.ComputerSystemOemIntelAMTSerialConsole_ControlMode {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTSerialConsole_ControlMode{}
+
+	controlMode := generated.ComputerSystemOemIntelAMTControlMode(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTControlMode(controlMode); err != nil {
+		return nil
+	}
+
+	return wrapper
+}
+
+func convertSOLStatusToGenerated(value string) *generated.ComputerSystemOemIntelAMTSerialConsole_SOLStatus {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTSerialConsole_SOLStatus{}
+
+	solStatus := generated.ComputerSystemOemIntelAMTSOLStatus(value)
+	if err := wrapper.FromComputerSystemOemIntelAMTSOLStatus(solStatus); err != nil {
+		return nil
+	}
+
+	return wrapper
+}
+
+func convertSerialUserConsentStatusToGenerated(value string) *generated.ComputerSystemOemIntelAMTSerialConsole_UserConsentStatus {
+	if value == "" {
+		return nil
+	}
+
+	wrapper := &generated.ComputerSystemOemIntelAMTSerialConsole_UserConsentStatus{}
 
 	status := generated.ComputerSystemOemIntelAMTUserConsentStatus(value)
 	if err := wrapper.FromComputerSystemOemIntelAMTUserConsentStatus(status); err != nil {

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -335,3 +335,179 @@ func assertGeneratedSerialConsoleAMT(t *testing.T, serialConsole *generated.Comp
 		t.Fatalf("expected UserConsentStatus=%q, got %q", generated.NotRequired, gotConsentStatus)
 	}
 }
+
+func TestConvertSerialConsoleToGenerated_WithNilWebSocket(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	maxSessions := int64(1)
+	console := &redfishv1.ComputerSystemHostSerialConsole{
+		MaxConcurrentSessions: &maxSessions,
+		WebSocket:             nil,
+		OEM:                   nil,
+	}
+
+	got := uc.convertSerialConsoleToGenerated(console)
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if got.MaxConcurrentSessions == nil || *got.MaxConcurrentSessions != 1 {
+		t.Fatalf("expected MaxConcurrentSessions=1, got %#v", got.MaxConcurrentSessions)
+	}
+
+	if got.WebSocket != nil {
+		t.Fatalf("expected WebSocket to be nil, got %#v", got.WebSocket)
+	}
+
+	if got.Oem != nil {
+		t.Fatalf("expected Oem to be nil, got %#v", got.Oem)
+	}
+}
+
+func TestConvertSerialConsoleOEMToGenerated_WithNilIntel(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	oem := &redfishv1.ComputerSystemHostSerialConsoleOEM{
+		Intel: nil,
+	}
+
+	got := uc.convertSerialConsoleOEMToGenerated(oem)
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if got.Intel != nil {
+		t.Fatalf("expected Intel to be nil when input Intel is nil, got %#v", got.Intel)
+	}
+}
+
+func TestConvertSerialConsoleOEMToGenerated_WithNilAMT(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	oem := &redfishv1.ComputerSystemHostSerialConsoleOEM{
+		Intel: &redfishv1.ComputerSystemHostSerialConsoleIntel{
+			AMT: nil,
+		},
+	}
+
+	got := uc.convertSerialConsoleOEMToGenerated(oem)
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	if got.Intel == nil {
+		t.Fatal("expected Intel to be non-nil")
+	}
+
+	if got.Intel.AMT != nil {
+		t.Fatalf("expected Intel.AMT to be nil, got %#v", got.Intel.AMT)
+	}
+}
+
+func TestConvertSerialConsoleOEMToGenerated_Nil(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	got := uc.convertSerialConsoleOEMToGenerated(nil)
+
+	if got != nil {
+		t.Fatalf("expected nil, got %#v", got)
+	}
+}
+
+func TestConvertSerialControlModeToGenerated_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSerialControlModeToGenerated("")
+
+	if got != nil {
+		t.Fatalf("expected nil for empty value, got %#v", got)
+	}
+}
+
+func TestConvertSOLStatusToGenerated_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSOLStatusToGenerated("")
+
+	if got != nil {
+		t.Fatalf("expected nil for empty value, got %#v", got)
+	}
+}
+
+func TestConvertSerialUserConsentStatusToGenerated_EmptyValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSerialUserConsentStatusToGenerated("")
+
+	if got != nil {
+		t.Fatalf("expected nil for empty value, got %#v", got)
+	}
+}
+
+func TestConvertSerialControlModeToGenerated_ValidValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSerialControlModeToGenerated("ACM")
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	mode, err := got.AsComputerSystemOemIntelAMTControlMode()
+	if err != nil {
+		t.Fatalf("failed to decode ControlMode: %v", err)
+	}
+
+	if mode != generated.ACM {
+		t.Fatalf("expected ACM, got %q", mode)
+	}
+}
+
+func TestConvertSOLStatusToGenerated_ValidValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSOLStatusToGenerated("Enabled")
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	status, err := got.AsComputerSystemOemIntelAMTSOLStatus()
+	if err != nil {
+		t.Fatalf("failed to decode SOLStatus: %v", err)
+	}
+
+	if status != generated.ComputerSystemOemIntelAMTSOLStatusEnabled {
+		t.Fatalf("expected Enabled, got %q", status)
+	}
+}
+
+func TestConvertSerialUserConsentStatusToGenerated_ValidValue(t *testing.T) {
+	t.Parallel()
+
+	got := convertSerialUserConsentStatusToGenerated("NotRequired")
+
+	if got == nil {
+		t.Fatal("expected non-nil result")
+	}
+
+	consent, err := got.AsComputerSystemOemIntelAMTUserConsentStatus()
+	if err != nil {
+		t.Fatalf("failed to decode UserConsentStatus: %v", err)
+	}
+
+	if consent != generated.NotRequired {
+		t.Fatalf("expected NotRequired, got %q", consent)
+	}
+}

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -161,88 +161,20 @@ func TestConvertStateToGenerated(t *testing.T) {
 		wantNil   bool
 		wantState generated.ResourceState
 	}{
-		{
-			name:      "StateEnabled",
-			state:     StateEnabled,
-			wantNil:   false,
-			wantState: generated.ResourceStateEnabled,
-		},
-		{
-			name:      "StateDisabled",
-			state:     StateDisabled,
-			wantNil:   false,
-			wantState: generated.ResourceStateDisabled,
-		},
-		{
-			name:      "StateStandbyOffline",
-			state:     StateStandbyOffline,
-			wantNil:   false,
-			wantState: generated.ResourceStateStandbyOffline,
-		},
-		{
-			name:      "StateStandbySpare",
-			state:     StateStandbySpare,
-			wantNil:   false,
-			wantState: generated.ResourceStateStandbySpare,
-		},
-		{
-			name:      "StateInTest",
-			state:     StateInTest,
-			wantNil:   false,
-			wantState: generated.ResourceStateInTest,
-		},
-		{
-			name:      "StateStarting",
-			state:     StateStarting,
-			wantNil:   false,
-			wantState: generated.ResourceStateStarting,
-		},
-		{
-			name:      "StateAbsent",
-			state:     StateAbsent,
-			wantNil:   false,
-			wantState: generated.ResourceStateAbsent,
-		},
-		{
-			name:      "StateUnavailableOffline",
-			state:     StateUnavailableOffline,
-			wantNil:   false,
-			wantState: generated.ResourceStateUnavailableOffline,
-		},
-		{
-			name:      "StateDeferring",
-			state:     StateDeferring,
-			wantNil:   false,
-			wantState: generated.ResourceStateDeferring,
-		},
-		{
-			name:      "StateQuiesced",
-			state:     StateQuiesced,
-			wantNil:   false,
-			wantState: generated.ResourceStateQuiesced,
-		},
-		{
-			name:      "StateUpdating",
-			state:     StateUpdating,
-			wantNil:   false,
-			wantState: generated.ResourceStateUpdating,
-		},
-		{
-			name:      "StateDegraded",
-			state:     StateDegraded,
-			wantNil:   false,
-			wantState: generated.ResourceStateDegraded,
-		},
-		{
-			name:    "UnknownState",
-			state:   "UnknownState",
-			wantNil: true,
-		},
-		{
-			name:    "EmptyState",
-			state:   "",
-			wantNil: true,
-		},
+		{name: "StateEnabled", state: StateEnabled, wantState: generated.ResourceStateEnabled},
+		{name: "StateDisabled", state: StateDisabled, wantState: generated.ResourceStateDisabled},
+		{name: "StateStandbyOffline", state: StateStandbyOffline, wantState: generated.ResourceStateStandbyOffline},
+		{name: "StateStandbySpare", state: StateStandbySpare, wantState: generated.ResourceStateStandbySpare},
+		{name: "StateInTest", state: StateInTest, wantState: generated.ResourceStateInTest},
+		{name: "StateStarting", state: StateStarting, wantState: generated.ResourceStateStarting},
+		{name: "StateAbsent", state: StateAbsent, wantState: generated.ResourceStateAbsent},
+		{name: "StateUnavailableOffline", state: StateUnavailableOffline, wantState: generated.ResourceStateUnavailableOffline},
+		{name: "StateDeferring", state: StateDeferring, wantState: generated.ResourceStateDeferring},
+		{name: "StateQuiesced", state: StateQuiesced, wantState: generated.ResourceStateQuiesced},
+		{name: "StateUpdating", state: StateUpdating, wantState: generated.ResourceStateUpdating},
+		{name: "StateDegraded", state: StateDegraded, wantState: generated.ResourceStateDegraded},
+		{name: "UnknownState", state: "UnknownState", wantNil: true},
+		{name: "EmptyState", state: "", wantNil: true},
 	}
 
 	uc := &ComputerSystemUseCase{}
@@ -256,7 +188,6 @@ func TestConvertStateToGenerated(t *testing.T) {
 	}
 }
 
-// validateConvertStateResult validates the result of convertStateToGenerated.
 func validateConvertStateResult(t *testing.T, uc *ComputerSystemUseCase, state string, wantNil bool, wantState generated.ResourceState) {
 	t.Helper()
 
@@ -281,5 +212,126 @@ func validateConvertStateResult(t *testing.T, uc *ComputerSystemUseCase, state s
 
 	if got != wantState {
 		t.Errorf("convertStateToGenerated(%q) got %v, want %v", state, got, wantState)
+	}
+}
+
+func TestConvertSerialConsoleToGeneratedNil(t *testing.T) {
+	t.Parallel()
+
+	uc := &ComputerSystemUseCase{}
+
+	if got := uc.convertSerialConsoleToGenerated(nil); got != nil {
+		t.Fatalf("expected nil SerialConsole, got %#v", got)
+	}
+}
+
+func TestGetComputerSystemSerialConsoleMapping(t *testing.T) {
+	t.Parallel()
+
+	serviceEnabled := true
+	interactive := true
+	maxSessions := int64(1)
+	consoleURI := "/relay/webrelay.ashx?host=system-1&mode=sol"
+
+	repo := &graphicalConsoleTestRepo{
+		system: &redfishv1.ComputerSystem{
+			ID:         "system-1",
+			Name:       "Test System",
+			SystemType: redfishv1.SystemTypePhysical,
+			PowerState: redfishv1.PowerStateOn,
+			SerialConsole: &redfishv1.ComputerSystemHostSerialConsole{
+				MaxConcurrentSessions: &maxSessions,
+				WebSocket: &redfishv1.ComputerSystemHostWebSocketConsole{
+					ConsoleURI:     &consoleURI,
+					Interactive:    &interactive,
+					ServiceEnabled: &serviceEnabled,
+				},
+				OEM: &redfishv1.ComputerSystemHostSerialConsoleOEM{
+					Intel: &redfishv1.ComputerSystemHostSerialConsoleIntel{
+						AMT: &redfishv1.ComputerSystemHostSerialConsoleAMT{
+							ControlMode:       "ACM",
+							SOLStatus:         "Enabled",
+							UserConsentStatus: "NotRequired",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	uc := &ComputerSystemUseCase{Repo: repo}
+
+	result, err := uc.GetComputerSystem(context.Background(), "system-1")
+	if err != nil {
+		t.Fatalf("GetComputerSystem returned error: %v", err)
+	}
+
+	assertGeneratedSerialConsoleMapping(t, result, consoleURI)
+}
+
+func assertGeneratedSerialConsoleMapping(t *testing.T, result *generated.ComputerSystemComputerSystem, consoleURI string) {
+	t.Helper()
+	serialConsole := assertGeneratedSerialConsoleCore(t, result, consoleURI)
+	assertGeneratedSerialConsoleAMT(t, serialConsole)
+}
+
+func assertGeneratedSerialConsoleCore(t *testing.T, result *generated.ComputerSystemComputerSystem, consoleURI string) *generated.ComputerSystemHostSerialConsole {
+	t.Helper()
+
+	if result.SerialConsole == nil {
+		t.Fatal("expected SerialConsole to be present")
+	}
+
+	if result.SerialConsole.MaxConcurrentSessions == nil || *result.SerialConsole.MaxConcurrentSessions != 1 {
+		t.Fatalf("expected MaxConcurrentSessions=1, got %#v", result.SerialConsole.MaxConcurrentSessions)
+	}
+
+	if result.SerialConsole.WebSocket == nil {
+		t.Fatal("expected WebSocket to be present")
+	}
+
+	if result.SerialConsole.WebSocket.ConsoleURI == nil || *result.SerialConsole.WebSocket.ConsoleURI != consoleURI {
+		t.Fatalf("expected ConsoleURI=%q, got %#v", consoleURI, result.SerialConsole.WebSocket.ConsoleURI)
+	}
+
+	if result.SerialConsole.WebSocket.ServiceEnabled == nil || !*result.SerialConsole.WebSocket.ServiceEnabled {
+		t.Fatalf("expected ServiceEnabled=true, got %#v", result.SerialConsole.WebSocket.ServiceEnabled)
+	}
+
+	return result.SerialConsole
+}
+
+func assertGeneratedSerialConsoleAMT(t *testing.T, serialConsole *generated.ComputerSystemHostSerialConsole) {
+	t.Helper()
+
+	if serialConsole.Oem == nil || serialConsole.Oem.Intel == nil || serialConsole.Oem.Intel.AMT == nil {
+		t.Fatal("expected SerialConsole.Oem.Intel.AMT to be present")
+	}
+
+	gotControlMode, err := serialConsole.Oem.Intel.AMT.ControlMode.AsComputerSystemOemIntelAMTControlMode()
+	if err != nil {
+		t.Fatalf("failed to decode ControlMode: %v", err)
+	}
+
+	if gotControlMode != generated.ACM {
+		t.Fatalf("expected ControlMode=%q, got %q", generated.ACM, gotControlMode)
+	}
+
+	gotSOLStatus, err := serialConsole.Oem.Intel.AMT.SOLStatus.AsComputerSystemOemIntelAMTSOLStatus()
+	if err != nil {
+		t.Fatalf("failed to decode SOLStatus: %v", err)
+	}
+
+	if gotSOLStatus != generated.ComputerSystemOemIntelAMTSOLStatusEnabled {
+		t.Fatalf("expected SOLStatus=%q, got %q", generated.ComputerSystemOemIntelAMTSOLStatusEnabled, gotSOLStatus)
+	}
+
+	gotConsentStatus, err := serialConsole.Oem.Intel.AMT.UserConsentStatus.AsComputerSystemOemIntelAMTUserConsentStatus()
+	if err != nil {
+		t.Fatalf("failed to decode UserConsentStatus: %v", err)
+	}
+
+	if gotConsentStatus != generated.NotRequired {
+		t.Fatalf("expected UserConsentStatus=%q, got %q", generated.NotRequired, gotConsentStatus)
 	}
 }

--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -42,6 +42,15 @@ const (
 	kvmConnectTypeKVMIP = "KVMIP"
 	kvmStatusActive     = "Active"
 
+	// SOL route and status constants.
+	solStatusActive         = "Active"
+	serialConsoleMode       = "sol"
+	redirectionWebSocketURI = "/relay/webrelay.ashx"
+	controlModeACM          = "ACM"
+	userConsentNotRequired  = "NotRequired"
+	statusPendingConsent    = "PendingConsent"
+	statusError             = "Error"
+
 	// Health state constants.
 	healthStateOK       = "OK"
 	healthStateWarning  = "Warning"
@@ -892,6 +901,7 @@ func (r *WsmanComputerSystemRepo) GetByID(ctx context.Context, systemID string) 
 	}
 
 	system.GraphicalConsole = r.buildGraphicalConsole(device.UseTLS, featuresV2)
+	system.SerialConsole = r.buildSerialConsole(systemID, featuresV2)
 
 	return system, nil
 }
@@ -924,10 +934,10 @@ func (r *WsmanComputerSystemRepo) buildGraphicalConsole(useTLS bool, featuresV2 
 		Intel: &redfishv1.ComputerSystemHostGraphicalConsoleIntel{
 			AMT: &redfishv1.ComputerSystemHostGraphicalConsoleAMT{
 				// Planned follow-up: query AMT_GeneralSettings from WS-Man to get actual control mode.
-				ControlMode: "ACM",
+				ControlMode: controlModeACM,
 				KVMStatus:   kvmStatus,
 				// Planned follow-up: query CIM_KVMRedirectionSAP and IPS_OptInService for actual user consent status.
-				UserConsentStatus: "NotRequired",
+				UserConsentStatus: userConsentNotRequired,
 			},
 		},
 	}
@@ -962,11 +972,82 @@ func determineKVMStatus(enableKVM, kvmAvailable bool, userConsent string, optInS
 		case optin.InSession:
 			return kvmStatusActive
 		case optin.NotStarted, optin.Requested, optin.Displayed:
-			return "PendingConsent"
+			return statusPendingConsent
 		case optin.Received:
 			return StateEnabled
 		default:
-			return "Error"
+			return statusError
+		}
+	}
+
+	return StateEnabled
+}
+
+func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2 dtov2.Features) *redfishv1.ComputerSystemHostSerialConsole {
+	serviceEnabled := featuresV2.EnableSOL
+	maxConcurrentSessions := int64(1)
+	interactive := true
+
+	var consoleURI *string
+
+	if featuresV2.Redirection {
+		uri := fmt.Sprintf("%s?host=%s&mode=%s", redirectionWebSocketURI, systemID, serialConsoleMode)
+		consoleURI = &uri
+	}
+
+	solStatus := determineSOLStatus(featuresV2.EnableSOL, featuresV2.Redirection, featuresV2.UserConsent, featuresV2.OptInState)
+
+	// Build OEM extensions with Intel AMT status.
+	oemExt := &redfishv1.ComputerSystemHostSerialConsoleOEM{
+		Intel: &redfishv1.ComputerSystemHostSerialConsoleIntel{
+			AMT: &redfishv1.ComputerSystemHostSerialConsoleAMT{
+				// Planned follow-up: query AMT_GeneralSettings from WS-Man to get actual control mode.
+				ControlMode: controlModeACM,
+				SOLStatus:   solStatus,
+				// Planned follow-up: query AMT_RedirectionService and IPS_OptInService for actual user consent status.
+				UserConsentStatus: userConsentNotRequired,
+			},
+		},
+	}
+
+	return &redfishv1.ComputerSystemHostSerialConsole{
+		MaxConcurrentSessions: &maxConcurrentSessions,
+		OEM:                   oemExt,
+		WebSocket: &redfishv1.ComputerSystemHostWebSocketConsole{
+			ConsoleURI:     consoleURI,
+			Interactive:    &interactive,
+			ServiceEnabled: &serviceEnabled,
+		},
+	}
+}
+
+// determineSOLStatus returns Intel AMT SOLStatus using SOL availability, enablement,
+// and user consent runtime state from IPS_OptInService.
+func determineSOLStatus(enableSOL, solAvailable bool, userConsent string, optInState int) string {
+	const (
+		userConsentSOL = "sol"
+		userConsentAll = "all"
+	)
+
+	if !solAvailable {
+		return StateDisabled
+	}
+
+	if !enableSOL {
+		return StateDisabled
+	}
+
+	consentRequired := userConsent == userConsentSOL || userConsent == userConsentAll
+	if consentRequired {
+		switch optin.OptInState(optInState) {
+		case optin.InSession:
+			return solStatusActive
+		case optin.NotStarted, optin.Requested, optin.Displayed:
+			return statusPendingConsent
+		case optin.Received:
+			return StateEnabled
+		default:
+			return statusError
 		}
 	}
 

--- a/redfish/internal/usecase/wsman_repo_test.go
+++ b/redfish/internal/usecase/wsman_repo_test.go
@@ -222,3 +222,203 @@ func TestBuildGraphicalConsole(t *testing.T) {
 		})
 	}
 }
+
+func TestDetermineSOLStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		enableSOL    bool
+		solAvailable bool
+		userConsent  string
+		optInState   int
+		want         string
+	}{
+		{
+			name:         "disabled when SOL not available",
+			enableSOL:    true,
+			solAvailable: false,
+			userConsent:  "sol",
+			optInState:   int(optin.InSession),
+			want:         StateDisabled,
+		},
+		{
+			name:         "disabled when SOL feature off",
+			enableSOL:    false,
+			solAvailable: true,
+			userConsent:  "sol",
+			optInState:   int(optin.InSession),
+			want:         StateDisabled,
+		},
+		{
+			name:         "active when consent required and in session",
+			enableSOL:    true,
+			solAvailable: true,
+			userConsent:  "sol",
+			optInState:   int(optin.InSession),
+			want:         solStatusActive,
+		},
+		{
+			name:         "pending consent when requested",
+			enableSOL:    true,
+			solAvailable: true,
+			userConsent:  "all",
+			optInState:   int(optin.Requested),
+			want:         "PendingConsent",
+		},
+		{
+			name:         "enabled when consent received",
+			enableSOL:    true,
+			solAvailable: true,
+			userConsent:  "all",
+			optInState:   int(optin.Received),
+			want:         StateEnabled,
+		},
+		{
+			name:         "error when consent required and unknown opt-in state",
+			enableSOL:    true,
+			solAvailable: true,
+			userConsent:  "sol",
+			optInState:   999,
+			want:         "Error",
+		},
+		{
+			name:         "enabled when consent not required",
+			enableSOL:    true,
+			solAvailable: true,
+			userConsent:  "none",
+			optInState:   int(optin.NotStarted),
+			want:         StateEnabled,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := determineSOLStatus(tt.enableSOL, tt.solAvailable, tt.userConsent, tt.optInState)
+			if got != tt.want {
+				t.Fatalf("determineSOLStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func assertSerialConsoleOEM(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantSOLStatus string) {
+	t.Helper()
+
+	if got.OEM == nil || got.OEM.Intel == nil || got.OEM.Intel.AMT == nil {
+		t.Fatal("OEM.Intel.AMT is nil")
+	}
+
+	amt := got.OEM.Intel.AMT
+
+	if amt.SOLStatus != wantSOLStatus {
+		t.Errorf("SOLStatus = %q, want %q", amt.SOLStatus, wantSOLStatus)
+	}
+
+	if amt.ControlMode != "ACM" {
+		t.Errorf("ControlMode = %q, want %q", amt.ControlMode, "ACM")
+	}
+
+	if amt.UserConsentStatus != "NotRequired" {
+		t.Errorf("UserConsentStatus = %q, want %q", amt.UserConsentStatus, "NotRequired")
+	}
+}
+
+func assertSerialConsole(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantEnabled bool, wantURI, wantSOLStatus string) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatal("buildSerialConsole() returned nil")
+	}
+
+	if got.MaxConcurrentSessions == nil || *got.MaxConcurrentSessions != 1 {
+		t.Errorf("MaxConcurrentSessions = %v, want 1", got.MaxConcurrentSessions)
+	}
+
+	if got.WebSocket == nil {
+		t.Fatal("WebSocket is nil")
+	}
+
+	if got.WebSocket.ServiceEnabled == nil || *got.WebSocket.ServiceEnabled != wantEnabled {
+		t.Errorf("ServiceEnabled = %v, want %v", got.WebSocket.ServiceEnabled, wantEnabled)
+	}
+
+	if got.WebSocket.Interactive == nil || !*got.WebSocket.Interactive {
+		t.Errorf("Interactive = %v, want true", got.WebSocket.Interactive)
+	}
+
+	if wantURI == "" {
+		if got.WebSocket.ConsoleURI != nil {
+			t.Errorf("ConsoleURI = %v, want nil", got.WebSocket.ConsoleURI)
+		}
+	} else {
+		if got.WebSocket.ConsoleURI == nil || *got.WebSocket.ConsoleURI != wantURI {
+			t.Errorf("ConsoleURI = %v, want %q", got.WebSocket.ConsoleURI, wantURI)
+		}
+	}
+
+	assertSerialConsoleOEM(t, got, wantSOLStatus)
+}
+
+func TestBuildSerialConsole(t *testing.T) {
+	t.Parallel()
+
+	repo := &WsmanComputerSystemRepo{log: logger.New("error")}
+
+	tests := []struct {
+		name          string
+		systemID      string
+		features      dtov2.Features
+		wantEnabled   bool
+		wantURI       string
+		wantSOLStatus string
+	}{
+		{
+			name:          "SOL not available - no URI",
+			systemID:      "system-1",
+			features:      dtov2.Features{EnableSOL: true, Redirection: false, UserConsent: "none"},
+			wantEnabled:   true,
+			wantURI:       "",
+			wantSOLStatus: StateDisabled,
+		},
+		{
+			name:          "SOL available with URI",
+			systemID:      "system-1",
+			features:      dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "none"},
+			wantEnabled:   true,
+			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus: StateEnabled,
+		},
+		{
+			name:          "SOL disabled",
+			systemID:      "system-1",
+			features:      dtov2.Features{EnableSOL: false, Redirection: true, UserConsent: "none"},
+			wantEnabled:   false,
+			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus: StateDisabled,
+		},
+		{
+			name:          "consent required and in session - active",
+			systemID:      "system-1",
+			features:      dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "sol", OptInState: int(optin.InSession)},
+			wantEnabled:   true,
+			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus: solStatusActive,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := repo.buildSerialConsole(tt.systemID, tt.features)
+			assertSerialConsole(t, got, tt.wantEnabled, tt.wantURI, tt.wantSOLStatus)
+		})
+	}
+}


### PR DESCRIPTION
Add SerialConsole data model and response mapping with SOL support metadata and targeted tests
SerialConsole
{
  "MaxConcurrentSessions": 1,
  "Oem": {
    "Intel": {
      "AMT": {
        "ControlMode": "ACM",
        "SOLStatus": "Disabled",
        "UserConsentStatus": "NotRequired"
      }
    }
  },
  "WebSocket": {
    "Interactive": true,
    "ServiceEnabled": true
  }
}
Note: "ControlMode" and "UserConsentStatus" are hardcoded, will implement in another PR.
