### PR TITLE
fix(config): resolve symlinks when locating config dir

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -219,6 +219,13 @@ func resolveConfigPath(configPathFlag string) (string, error) {
 		return "", err
 	}
 
+	// Resolve symlinks so invocation via a wrapper symlink (e.g. /usr/local/bin/dmt-console
+	// → /usr/local/device-management-toolkit/console) anchors config beside the real binary
+	// rather than beside the symlink.
+	if resolved, evalErr := filepath.EvalSymlinks(ex); evalErr == nil {
+		ex = resolved
+	}
+
 	exPath := filepath.Dir(ex)
 
 	return filepath.Join(exPath, "config", "config.yml"), nil


### PR DESCRIPTION
os.Executable() can return a symlink path; using filepath.Dir on it anchors config beside the symlink rather than the real binary. On macOS this surfaces when /usr/local/bin/dmt-console symlinks into /usr/local/device-management-toolkit/console: the app tries to mkdir /usr/local/bin/config and fails with EACCES.