### PR TITLE
feat(tray): enforce single instance and expose reachable URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,8 @@ APP_COMMON_NAME=console.local
 APP_DISABLE_CIRA=true
 
 # HTTP Server
-HTTP_HOST=localhost
+# Empty or 0.0.0.0 binds all interfaces.
+HTTP_HOST=
 HTTP_PORT=8181
 WS_COMPRESSION=false
 HTTP_ALLOWED_ORIGINS=*

--- a/cmd/app/tray.go
+++ b/cmd/app/tray.go
@@ -4,8 +4,10 @@ package main
 
 import (
 	"log"
+	"net"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/device-management-toolkit/console/config"
@@ -26,28 +28,31 @@ func isTerminal() bool {
 }
 
 func runWithTray(cfg *config.Config, l logger.Interface) {
-	// When launched from a terminal, re-exec in the background so the
-	// user gets their shell back and logs go to a file.
+	urls := listenURLs(cfg)
+	primaryURL := urls[0]
+
+	// Must run before re-exec so the parent surfaces the duplicate, not the soon-to-exit child.
+	ensureSingleInstance(primaryURL)
+
 	if os.Getenv("DMT_BACKGROUND") == "" && isTerminal() {
+		// Print before re-exec; after fork, stderr is the log file.
+		for _, u := range urls {
+			log.Printf("DMT Console running at %s", u)
+		}
+
 		relaunchInBackground()
 	}
 
-	// Build the URL for the web UI
-	scheme := "http"
-	if cfg.TLS.Enabled {
-		scheme = "https"
-	}
-	url := scheme + "://localhost:" + cfg.Port
-
-	// Create tray manager
 	trayManager := tray.New(tray.Config{
 		AppName:  "DMT Console",
-		URL:      url,
+		URL:      primaryURL,
 		Headless: isHeadlessBuild,
 		OnReady: func() {
-			// Start the server in a goroutine
 			go runAppFunc(cfg, l)
-			log.Printf("DMT Console running at %s", url)
+
+			for _, u := range urls {
+				log.Printf("DMT Console running at %s", u)
+			}
 		},
 		OnQuit: func() {
 			log.Println("Shutting down DMT Console...")
@@ -78,4 +83,118 @@ func runWithTray(cfg *config.Config, l logger.Interface) {
 
 	// Run the tray (this blocks until quit)
 	trayManager.Run()
+}
+
+// listenURLs returns reachable URLs; the first entry is the tray's "open in browser" target.
+func listenURLs(cfg *config.Config) []string {
+	scheme := "http"
+	if cfg.TLS.Enabled {
+		scheme = "https"
+	}
+
+	hosts := listenHosts(cfg.Host)
+	urls := make([]string, 0, len(hosts))
+
+	for _, h := range hosts {
+		urls = append(urls, scheme+"://"+net.JoinHostPort(unbracketHost(h), cfg.Port))
+	}
+
+	return urls
+}
+
+// unbracketHost strips a single pair of surrounding brackets from a literal IPv6
+// host so net.JoinHostPort doesn't double-wrap (e.g. "[::1]" → "::1").
+func unbracketHost(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+
+	return host
+}
+
+// listenHosts always returns at least one entry ("localhost") so listenURLs[0] is safe.
+func listenHosts(cfgHost string) []string {
+	if !isWildcardListenHost(cfgHost) {
+		return []string{cfgHost}
+	}
+
+	hosts := []string{"localhost"}
+
+	ifaces, err := net.Interfaces()
+	if err != nil {
+		return hosts
+	}
+
+	seen := map[string]struct{}{}
+
+	for _, iface := range ifaces {
+		if !isReachableInterface(iface) {
+			continue
+		}
+
+		hosts = appendInterfaceIPv4s(hosts, iface, seen)
+	}
+
+	return hosts
+}
+
+func isReachableInterface(iface net.Interface) bool {
+	if iface.Flags&net.FlagUp == 0 || iface.Flags&net.FlagLoopback != 0 {
+		return false
+	}
+
+	return !isVirtualInterfaceName(iface.Name)
+}
+
+func appendInterfaceIPv4s(hosts []string, iface net.Interface, seen map[string]struct{}) []string {
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return hosts
+	}
+
+	for _, addr := range addrs {
+		ipNet, ok := addr.(*net.IPNet)
+		if !ok {
+			continue
+		}
+
+		if ipNet.IP.IsLoopback() || ipNet.IP.IsLinkLocalUnicast() || ipNet.IP.To4() == nil {
+			continue
+		}
+
+		ip := ipNet.IP.String()
+		if _, dup := seen[ip]; dup {
+			continue
+		}
+
+		seen[ip] = struct{}{}
+		hosts = append(hosts, ip)
+	}
+
+	return hosts
+}
+
+// isVirtualInterfaceName filters out container/VM/VPN bridges that bind addresses
+// the user can't actually reach the tray from. Conservative — we'd rather miss
+// a real NIC than spam the user with a dozen 172.17.x.x docker URLs.
+func isVirtualInterfaceName(name string) bool {
+	prefixes := []string{
+		"docker", "br-", "veth",
+		"tun", "tap", "utun",
+		"virbr", "vmnet", "vboxnet",
+		"awdl", "llw",
+		"zt", "wg",
+	}
+
+	for _, p := range prefixes {
+		if strings.HasPrefix(name, p) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func isWildcardListenHost(host string) bool {
+	return host == "" || host == "0.0.0.0" || host == "::" || host == "[::]"
 }

--- a/cmd/app/tray_test.go
+++ b/cmd/app/tray_test.go
@@ -1,0 +1,117 @@
+//go:build tray
+
+package main
+
+import (
+	"testing"
+
+	"github.com/device-management-toolkit/console/config"
+)
+
+func TestIsWildcardListenHost(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]bool{
+		"":          true,
+		"0.0.0.0":   true,
+		"::":        true,
+		"[::]":      true,
+		"localhost": false,
+		"127.0.0.1": false,
+		"10.0.0.1":  false,
+	}
+
+	for host, want := range tests {
+		host, want := host, want
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isWildcardListenHost(host); got != want {
+				t.Errorf("isWildcardListenHost(%q) = %v, want %v", host, got, want)
+			}
+		})
+	}
+}
+
+func TestListenURLsBracketedIPv6(t *testing.T) {
+	t.Parallel()
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{
+			Host: "[::1]",
+			Port: "8181",
+			TLS:  config.TLS{Enabled: true},
+		},
+	}
+
+	urls := listenURLs(cfg)
+	if len(urls) != 1 {
+		t.Fatalf("listenURLs returned %d URLs, want 1: %v", len(urls), urls)
+	}
+
+	if want := "https://[::1]:8181"; urls[0] != want {
+		t.Errorf("listenURLs[0] = %q, want %q", urls[0], want)
+	}
+}
+
+func TestUnbracketHost(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"[::1]":     "::1",
+		"[fe80::1]": "fe80::1",
+		"[]":        "",
+		"::1":       "::1",
+		"localhost": "localhost",
+		"":          "",
+		"[":         "[",
+		"]":         "]",
+	}
+
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			if got := unbracketHost(in); got != want {
+				t.Errorf("unbracketHost(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}
+
+func TestIsVirtualInterfaceName(t *testing.T) {
+	t.Parallel()
+
+	virtual := []string{
+		"docker0", "br-1234abcd", "veth0a1b2c",
+		"tun0", "tap0", "utun3",
+		"virbr0", "vmnet1", "vboxnet0",
+		"awdl0", "llw0",
+		"zt0", "wg0",
+	}
+	for _, name := range virtual {
+		name := name
+		t.Run("virtual/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			if !isVirtualInterfaceName(name) {
+				t.Errorf("isVirtualInterfaceName(%q) = false, want true", name)
+			}
+		})
+	}
+
+	physical := []string{
+		"eth0", "eth1", "en0", "en1", "wlan0", "wlp3s0", "enp0s31f6",
+	}
+	for _, name := range physical {
+		name := name
+		t.Run("physical/"+name, func(t *testing.T) {
+			t.Parallel()
+
+			if isVirtualInterfaceName(name) {
+				t.Errorf("isVirtualInterfaceName(%q) = true, want false", name)
+			}
+		})
+	}
+}

--- a/cmd/app/tray_unix.go
+++ b/cmd/app/tray_unix.go
@@ -10,8 +10,116 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
+	"strings"
 	"syscall"
 )
+
+// Kept open for process lifetime so the kernel retains the flock.
+var instanceLockFD = -1
+
+const (
+	lockDirPerm     os.FileMode = 0o755
+	lockFilePerm    os.FileMode = 0o644
+	lockReadBufSize             = 1024
+	lockPayloadKeys             = 2 // "<pid>\n<url>\n"
+)
+
+// ensureSingleInstance acquires a per-user flock; the FD is inherited across
+// the background re-exec via DMT_LOCK_FD so the lock survives parent exit.
+func ensureSingleInstance(url string) {
+	if fdStr := os.Getenv("DMT_LOCK_FD"); fdStr != "" {
+		if fd, err := strconv.Atoi(fdStr); err == nil {
+			instanceLockFD = fd
+			writeLockPayload(fd, url)
+		}
+
+		return
+	}
+
+	path := lockFilePath()
+	if err := os.MkdirAll(filepath.Dir(path), lockDirPerm); err != nil {
+		log.Printf("Failed to create lock directory: %v", err)
+
+		return
+	}
+
+	fd, err := syscall.Open(path, syscall.O_CREAT|syscall.O_RDWR, uint32(lockFilePerm))
+	if err != nil {
+		log.Printf("Failed to open lock file %s: %v", path, err)
+
+		return
+	}
+
+	if err := syscall.Flock(fd, syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		runningURL := readLockURL(fd)
+		if runningURL == "" {
+			runningURL = url
+		}
+
+		_ = syscall.Close(fd)
+
+		log.Printf("DMT Console is already running; signaling user at %s", runningURL)
+		surfaceRunningInstance(runningURL)
+		os.Exit(0)
+	}
+
+	instanceLockFD = fd
+
+	writeLockPayload(fd, url)
+}
+
+// writeLockPayload records "<pid>\n<url>\n" so a duplicate invocation can
+// open the running instance's URL instead of the new invocation's config.
+func writeLockPayload(fd int, url string) {
+	_ = syscall.Ftruncate(fd, 0)
+	_, _ = syscall.Pwrite(fd, []byte(strconv.Itoa(os.Getpid())+"\n"+url+"\n"), 0)
+}
+
+// readLockURL reads the URL line from a lock file. Returns "" when missing/malformed.
+func readLockURL(fd int) string {
+	buf := make([]byte, lockReadBufSize)
+
+	n, err := syscall.Pread(fd, buf, 0)
+	if err != nil || n <= 0 {
+		return ""
+	}
+
+	parts := strings.SplitN(strings.TrimRight(string(buf[:n]), "\n"), "\n", lockPayloadKeys)
+	if len(parts) < lockPayloadKeys {
+		return ""
+	}
+
+	return parts[1]
+}
+
+func surfaceRunningInstance(url string) {
+	opener := "xdg-open"
+	if runtime.GOOS == "darwin" {
+		opener = "open"
+	}
+
+	if err := exec.CommandContext(context.Background(), opener, url).Start(); err != nil {
+		log.Printf("Failed to open browser: %v", err)
+	}
+}
+
+func lockFilePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), "dmt-console.lock")
+	}
+
+	if runtime.GOOS == "darwin" {
+		return filepath.Join(home, "Library", "Caches", "device-management-toolkit", "dmt-console.lock")
+	}
+
+	if dir := os.Getenv("XDG_RUNTIME_DIR"); dir != "" {
+		return filepath.Join(dir, "device-management-toolkit", "dmt-console.lock")
+	}
+
+	return filepath.Join(home, ".cache", "device-management-toolkit", "dmt-console.lock")
+}
 
 // logDir returns the conventional log directory for the current platform.
 // macOS: ~/Library/Logs/device-management-toolkit
@@ -61,6 +169,13 @@ func relaunchInBackground() {
 	cmd.Env = append(os.Environ(), "DMT_BACKGROUND=1")
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Setsid: true,
+	}
+
+	// Hand the flock FD to the child (becomes FD 3) so the lock survives parent exit.
+	if instanceLockFD >= 0 {
+		lockFile := os.NewFile(uintptr(instanceLockFD), "dmt-console.lock")
+		cmd.ExtraFiles = []*os.File{lockFile}
+		cmd.Env = append(cmd.Env, "DMT_LOCK_FD=3")
 	}
 
 	if err := cmd.Start(); err != nil {

--- a/cmd/app/tray_windows.go
+++ b/cmd/app/tray_windows.go
@@ -10,12 +10,105 @@ import (
 	"os/exec"
 	"path/filepath"
 	"syscall"
+	"unsafe"
 )
 
 // detachedProcess is the Windows CreationFlag that runs the child without
 // inheriting the parent console. Defined here to avoid pulling in
 // golang.org/x/sys/windows just for the constant.
 const detachedProcess = 0x00000008
+
+// CreateMutexW returns ERROR_ALREADY_EXISTS when another instance holds the named mutex.
+const errorAlreadyExists syscall.Errno = 183
+
+const mutexName = "Local\\DMTConsoleTray"
+
+// synchronize is the minimum DesiredAccess for OpenMutexW.
+const synchronize = 0x00100000
+
+// ensureSingleInstance prevents concurrent tray processes via a named mutex.
+//
+// The mutex handle does not survive process exit and cannot be passed to the
+// re-execed child on Windows, so:
+//   - In the terminal parent (which is about to fork and exit), we probe with
+//     OpenMutexW; if a duplicate is found, surface it and exit, otherwise let
+//     the re-execed child take the persistent hold.
+//   - In the re-execed child or non-terminal launch (GUI/service), we hold
+//     the mutex with CreateMutexW for process lifetime.
+func ensureSingleInstance(url string) {
+	namePtr, err := syscall.UTF16PtrFromString(mutexName)
+	if err != nil {
+		return
+	}
+
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+
+	if shouldHoldInstanceMutex() {
+		acquireInstanceMutex(kernel32, namePtr, url)
+
+		return
+	}
+
+	probeInstanceMutex(kernel32, namePtr, url)
+}
+
+// shouldHoldInstanceMutex reports whether this process is the persistent tray
+// process (re-execed child or non-terminal launch). The terminal parent that
+// is about to call relaunchInBackground returns false.
+func shouldHoldInstanceMutex() bool {
+	return os.Getenv("DMT_BACKGROUND") != "" || !isTerminal()
+}
+
+func acquireInstanceMutex(kernel32 *syscall.LazyDLL, namePtr *uint16, url string) {
+	createMutex := kernel32.NewProc("CreateMutexW")
+
+	handle, _, lastErr := createMutex.Call(0, 0, uintptr(unsafe.Pointer(namePtr)))
+	if handle == 0 {
+		return
+	}
+
+	if errno, ok := lastErr.(syscall.Errno); ok && errno == errorAlreadyExists {
+		log.Printf("DMT Console is already running; signalling user at %s", url)
+		surfaceRunningInstance(url)
+		os.Exit(0)
+	}
+}
+
+func probeInstanceMutex(kernel32 *syscall.LazyDLL, namePtr *uint16, url string) {
+	openMutex := kernel32.NewProc("OpenMutexW")
+
+	handle, _, _ := openMutex.Call(synchronize, 0, uintptr(unsafe.Pointer(namePtr)))
+	if handle == 0 {
+		return
+	}
+
+	closeHandle := kernel32.NewProc("CloseHandle")
+	_, _, _ = closeHandle.Call(handle)
+
+	log.Printf("DMT Console is already running; signalling user at %s", url)
+	surfaceRunningInstance(url)
+	os.Exit(0)
+}
+
+func surfaceRunningInstance(url string) {
+	if isHeadlessBuild {
+		user32 := syscall.NewLazyDLL("user32.dll")
+		messageBox := user32.NewProc("MessageBoxW")
+
+		text, _ := syscall.UTF16PtrFromString("DMT Console is already running in the system tray.\nAPI: " + url)
+		caption, _ := syscall.UTF16PtrFromString("DMT Console")
+
+		const mbIconInformation = 0x40
+		messageBox.Call(0, uintptr(unsafe.Pointer(text)), uintptr(unsafe.Pointer(caption)), mbIconInformation)
+
+		return
+	}
+
+	// rundll32 avoids cmd.exe's metacharacter parsing on URLs with querystrings.
+	if err := exec.CommandContext(context.Background(), "rundll32", "url.dll,FileProtocolHandler", url).Start(); err != nil {
+		log.Printf("Failed to open browser: %v", err)
+	}
+}
 
 // logDir returns the Windows-conventional log directory for the app.
 func logDir() string {

--- a/config/config.go
+++ b/config/config.go
@@ -45,7 +45,7 @@ type (
 
 	// HTTP -.
 	HTTP struct {
-		Host           string   `env-required:"true" yaml:"host" env:"HTTP_HOST"`
+		Host           string   `yaml:"host" env:"HTTP_HOST"`
 		Port           string   `env-required:"true" yaml:"port" env:"HTTP_PORT"`
 		AllowedOrigins []string `env-required:"true" yaml:"allowed_origins" env:"HTTP_ALLOWED_ORIGINS"`
 		AllowedHeaders []string `env-required:"true" yaml:"allowed_headers" env:"HTTP_ALLOWED_HEADERS"`
@@ -154,7 +154,7 @@ func defaultConfig() *Config {
 			DisableCIRA:          true,
 		},
 		HTTP: HTTP{
-			Host:           "localhost",
+			Host:           "",
 			Port:           "8181",
 			AllowedOrigins: []string{"*"},
 			AllowedHeaders: []string{"*"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -31,7 +31,7 @@ func TestNewConfig_Defaults(t *testing.T) { //nolint:paralleltest // cannot have
 	assert.Equal(t, "DEVELOPMENT", cfg.Version)
 	assert.Equal(t, "test", cfg.EncryptionKey)
 
-	assert.Equal(t, "localhost", cfg.Host)
+	assert.Equal(t, "", cfg.Host)
 	assert.Equal(t, "8181", cfg.Port)
 	assert.Equal(t, []string{"*"}, cfg.AllowedOrigins)
 	assert.Equal(t, []string{"*"}, cfg.AllowedHeaders)

--- a/internal/controller/httpapi/ui.go
+++ b/internal/controller/httpapi/ui.go
@@ -6,6 +6,7 @@ import (
 	"embed"
 	"io/fs"
 	"log"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -122,7 +123,7 @@ func injectConfigToMainJS(l logger.Interface, cfg *config.Config) string {
 	}
 
 	data = injectPlaceholders(data, map[string]string{
-		"##CONSOLE_SERVER_API##": protocol + cfg.Host + ":" + cfg.Port,
+		"##CONSOLE_SERVER_API##": consoleServerAPIBase(protocol, cfg.Host, cfg.Port),
 	})
 
 	// Write to /tmp
@@ -135,6 +136,34 @@ func injectConfigToMainJS(l logger.Interface, cfg *config.Config) string {
 	}
 
 	return tempFile
+}
+
+// Returns "" on wildcard hosts so the UI uses same-origin requests matching the user's URL/SNI.
+func consoleServerAPIBase(protocol, host, port string) string {
+	if isWildcardHost(host) {
+		return ""
+	}
+
+	return protocol + net.JoinHostPort(unbracket(host), port)
+}
+
+// unbracket strips a single pair of surrounding square brackets from a literal
+// IPv6 host so net.JoinHostPort doesn't double-wrap (e.g. "[::1]" → "::1").
+func unbracket(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+
+	return host
+}
+
+func isWildcardHost(host string) bool {
+	switch host {
+	case "", "0.0.0.0", "::", "[::]":
+		return true
+	}
+
+	return false
 }
 
 func injectPlaceholders(content []byte, replacements map[string]string) []byte {

--- a/internal/controller/httpapi/ui_test.go
+++ b/internal/controller/httpapi/ui_test.go
@@ -1,0 +1,80 @@
+//go:build !noui
+
+package httpapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConsoleServerAPIBase(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		protocol string
+		host     string
+		port     string
+		want     string
+	}{
+		{
+			name:     "wildcard empty host returns relative URL",
+			protocol: "https://",
+			host:     "",
+			port:     "8181",
+			want:     "",
+		},
+		{
+			name:     "wildcard 0.0.0.0 returns relative URL",
+			protocol: "http://",
+			host:     "0.0.0.0",
+			port:     "8181",
+			want:     "",
+		},
+		{
+			name:     "wildcard :: returns relative URL",
+			protocol: "https://",
+			host:     "::",
+			port:     "8181",
+			want:     "",
+		},
+		{
+			name:     "localhost returns absolute URL",
+			protocol: "https://",
+			host:     "localhost",
+			port:     "8181",
+			want:     "https://localhost:8181",
+		},
+		{
+			name:     "specific IP returns absolute URL",
+			protocol: "http://",
+			host:     "192.168.10.13",
+			port:     "8181",
+			want:     "http://192.168.10.13:8181",
+		},
+		{
+			name:     "IPv6 address is bracketed",
+			protocol: "https://",
+			host:     "fe80::1",
+			port:     "8181",
+			want:     "https://[fe80::1]:8181",
+		},
+		{
+			name:     "already-bracketed IPv6 is not double-wrapped",
+			protocol: "https://",
+			host:     "[::1]",
+			port:     "8181",
+			want:     "https://[::1]:8181",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := consoleServerAPIBase(tt.protocol, tt.host, tt.port)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
  A second invocation now detects the running instance via a per-user
  flock (Unix) or named mutex (Windows), opens the existing tray's URL
  in the browser, and exits cleanly rather than racing on port 8181.
  The lock FD is inherited across the background re-exec so it survives
  parent exit.

  Default HTTP_HOST changes from "localhost" to wildcard so the tray
  is reachable from other devices on the LAN. The tray menu and
  startup log enumerate every routable IPv4, filtering virtual bridges
  (docker, veth, br-, tun/tap, virbr, vmnet, vboxnet, wg, zt, awdl,
  llw) and deduping.

  When bound to a wildcard, the UI's injected ##CONSOLE_SERVER_API##
  resolves to a relative URL so same-origin fetches match the user's
  actual host/SNI.

Refs: Package Console as an installer #870