### PR TITLE
revert: correct inverted GIN_MODE condition in handleDebugMode

### DIFF
--- a/cmd/app/main.go
+++ b/cmd/app/main.go
@@ -22,10 +22,6 @@ var (
 	ErrSecretStoreTokenNotConfigured   = errors.New("secret store token not configured")
 )
 
-// ginModeDebug is the value of GIN_MODE that opts into developer-mode
-// behaviors (e.g. auto-launching a browser on startup).
-const ginModeDebug = "debug"
-
 // Function pointers for better testability.
 var (
 	initializeConfigFunc = config.NewConfig
@@ -103,17 +99,9 @@ func handleDebugMode(cfg *config.Config, l logger.Interface) {
 		return
 	}
 
-	if shouldAutoLaunchBrowser() {
+	if os.Getenv("GIN_MODE") != "debug" {
 		go launchBrowser(cfg)
 	}
-}
-
-// shouldAutoLaunchBrowser reports whether the binary should fire a browser
-// launch on startup. Only true when a developer has explicitly opted into
-// debug mode; containers and services run with GIN_MODE=release or unset and
-// fall through without attempting to invoke xdg-open / open / start.
-func shouldAutoLaunchBrowser() bool {
-	return os.Getenv("GIN_MODE") == ginModeDebug
 }
 
 func handleSecretsConfig(cfg *config.Config) (security.Storager, error) {

--- a/cmd/app/main_test.go
+++ b/cmd/app/main_test.go
@@ -13,35 +13,6 @@ import (
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
 
-func TestShouldAutoLaunchBrowser(t *testing.T) {
-	tests := []struct {
-		name    string
-		ginMode string
-		setEnv  bool
-		want    bool
-	}{
-		{name: "unset", setEnv: false, want: false},
-		{name: "empty", ginMode: "", setEnv: true, want: false},
-		{name: "release", ginMode: "release", setEnv: true, want: false},
-		{name: "test", ginMode: "test", setEnv: true, want: false},
-		{name: "debug", ginMode: ginModeDebug, setEnv: true, want: true},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			if tc.setEnv {
-				t.Setenv("GIN_MODE", tc.ginMode)
-			} else {
-				_ = os.Unsetenv("GIN_MODE")
-			}
-
-			if got := shouldAutoLaunchBrowser(); got != tc.want {
-				t.Errorf("shouldAutoLaunchBrowser() with GIN_MODE=%q: got %v, want %v", tc.ginMode, got, tc.want)
-			}
-		})
-	}
-}
-
 func TestMainFunction(_ *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying env variables.
 	os.Setenv("GIN_MODE", "debug")
 


### PR DESCRIPTION
Reverts device-management-toolkit/console#979

In release mode, launching the browser is a requirement.