### PR TITLE
fix: default browser launch host to configured host

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Warning: Key Not Found, Generate new key? Y/N
 
 You’ll run two components during development:
 
-- **Console** – the backend service (Go Service)  
+- **Console** – the backend service (Go Service)
 - **Web UI** – the frontend (for the Angular Web UI)
 
 Local development can be done on **Linux**, **macOS**, and **Windows**. On Windows, WSL is recommended if you plan to use `make`, but it’s not required for running Console directly.
@@ -154,10 +154,12 @@ This will use the `DB_URL` you configured in `.env`.
 Console supports multiple build configurations optimized for different use cases:
 
 #### Default Build
+
 - Full build with embedded web UI
 - Ideal for development and single-instance deployments
 
 #### `noui` Build (Headless/API-only)
+
 - Excludes embedded web UI from binary
 - **Reduces binary size** by ~30MB
 - All API endpoints remain fully functional
@@ -168,6 +170,7 @@ Console supports multiple build configurations optimized for different use cases
 **Configuration for headless builds:**
 
 Edit `config.yml`:
+
 ```yaml
 ui:
   # Redirect UI requests to external frontend (optional)
@@ -177,11 +180,13 @@ ui:
 ```
 
 Or use environment variable:
+
 ```sh
 UI_EXTERNAL_URL=https://your-ui-domain.com ./console-noui
 ```
 
 **Build commands:**
+
 ```sh
 # Default build (with UI) for current platform
 make build
@@ -195,6 +200,7 @@ make build-all-platforms
 ```
 
 **Manual build examples:**
+
 ```sh
 # Build for current platform
 go build -o console ./cmd/app
@@ -232,7 +238,7 @@ npm run enterprise
 
 Check the output of `npm run enterprise` to verify the port (default is 4200), then open the UI in your browser at:
 
-```
+```sh
 http://localhost:4200
 ```
 
@@ -250,9 +256,11 @@ Console exposes the OpenAPI specification two ways:
 1. **Live HTTP endpoint** (always available when the server runs):
    - `http://localhost:8181/api/openapi.json`
 2. **Regenerate `doc/openapi.json` on disk** (used by CI to publish to SwaggerHub):
+
    ```sh
    make openapi
    ```
+
    Equivalent to `go run ./cmd/openapi-gen` — a standalone binary that writes `doc/openapi.json` and exits without starting the server.
 3. **To add API Documentation**: Check wiki `https://github.com/device-management-toolkit/console/wiki/API-Documentation-to-Console`
 
@@ -263,8 +271,8 @@ Console exposes the OpenAPI specification two ways:
 - Ensure code is formatted correctly with `gofumpt -l -w -extra ./`
 - Ensure all unit tests pass with `go test ./...`
 - Ensure code has been linted with:
-  - Windows: `docker run --rm -v ${pwd}:/app -w /app golangci/golangci-lint:latest golangci-lint run --config=./.golangci.yml -v`
-  - Unix: `docker run --rm -v .:/app -w /app golangci/golangci-lint:latest golangci-lint run --config=./.golangci.yml -v`
+  - Windows: `docker run --rm --pull always -v ${pwd}:/app -w /app golangci/golangci-lint:latest golangci-lint run --config=./.golangci.yml -v`
+  - Unix: `docker run --rm --pull always -v .:/app -w /app golangci/golangci-lint:latest golangci-lint run --config=./.golangci.yml -v`
 
 ## Fuzz Testing
 

--- a/cmd/app/browser.go
+++ b/cmd/app/browser.go
@@ -5,6 +5,7 @@ package main
 import (
 	"context"
 	"log"
+	"net"
 	"os/exec"
 	"runtime"
 
@@ -17,7 +18,25 @@ func launchBrowser(cfg *config.Config) {
 		scheme = "https"
 	}
 
-	if err := openBrowser(scheme+"://localhost:"+cfg.Port, runtime.GOOS); err != nil {
+	host := cfg.Host
+
+	// Strip brackets from bracketed IPv6 literals (e.g. [::1] → ::1) before
+	// the wildcard check so both [::] and [::1] are handled uniformly.
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		host = host[1 : len(host)-1]
+	}
+
+	// Wildcard bind addresses are not directly navigable; normalise them to
+	// localhost. Preserve loopback addresses such as ::1 so net.JoinHostPort
+	// can format them correctly for browser navigation.
+	if host == "" || host == "0.0.0.0" || host == "::" {
+		host = "localhost"
+	}
+
+	url := scheme + "://" + net.JoinHostPort(host, cfg.Port)
+	log.Printf("launchBrowser: opening %s", url)
+
+	if err := openBrowser(url, runtime.GOOS); err != nil {
 		log.Printf("Skipping browser launch: %v", err)
 	}
 }
@@ -34,6 +53,13 @@ func (e *RealCommandExecutor) Execute(name string, arg ...string) error {
 	return exec.CommandContext(context.Background(), name, arg...).Start()
 }
 
+// windowsCmdFlag is the /c flag passed to cmd.exe to run a command and exit.
+// windowsCmdStart is the Windows shell verb that opens a URL in the default browser.
+const (
+	windowsCmdFlag  = "/c"
+	windowsCmdStart = "start"
+)
+
 // Global command executor, can be replaced in tests.
 var cmdExecutor CommandExecutor = &RealCommandExecutor{}
 
@@ -48,7 +74,7 @@ func openBrowser(url, currentOS string) error {
 		args = []string{url}
 	case "windows":
 		cmd = "cmd"
-		args = []string{"/c", "start", url}
+		args = []string{windowsCmdFlag, windowsCmdStart, url}
 	default:
 		cmd = "xdg-open"
 		args = []string{url}

--- a/cmd/app/browser.go
+++ b/cmd/app/browser.go
@@ -18,20 +18,7 @@ func launchBrowser(cfg *config.Config) {
 		scheme = "https"
 	}
 
-	host := cfg.Host
-
-	// Strip brackets from bracketed IPv6 literals (e.g. [::1] → ::1) before
-	// the wildcard check so both [::] and [::1] are handled uniformly.
-	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
-		host = host[1 : len(host)-1]
-	}
-
-	// Wildcard bind addresses are not directly navigable; normalise them to
-	// localhost. Preserve loopback addresses such as ::1 so net.JoinHostPort
-	// can format them correctly for browser navigation.
-	if host == "" || host == "0.0.0.0" || host == "::" {
-		host = "localhost"
-	}
+	host := navigableHost(cfg.Host)
 
 	url := scheme + "://" + net.JoinHostPort(host, cfg.Port)
 	log.Printf("launchBrowser: opening %s", url)

--- a/cmd/app/browser_test.go
+++ b/cmd/app/browser_test.go
@@ -37,6 +37,10 @@ func expectedOpenBrowserArgs(url string) (cmd string, args []string) {
 
 func TestOpenBrowserWindows(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	mockCmdExecutor.On("Execute", "cmd", []string{windowsCmdFlag, windowsCmdStart, "http://localhost:8080"}).Return(nil)
@@ -48,6 +52,10 @@ func TestOpenBrowserWindows(t *testing.T) { //nolint:paralleltest // cannot have
 
 func TestOpenBrowserDarwin(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	mockCmdExecutor.On("Execute", "open", []string{"http://localhost:8080"}).Return(nil)
@@ -59,6 +67,10 @@ func TestOpenBrowserDarwin(t *testing.T) { //nolint:paralleltest // cannot have 
 
 func TestOpenBrowserLinux(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	mockCmdExecutor.On("Execute", "xdg-open", []string{"http://localhost:8080"}).Return(nil)
@@ -70,6 +82,10 @@ func TestOpenBrowserLinux(t *testing.T) { //nolint:paralleltest // cannot have s
 
 func TestLaunchBrowserEmptyHostDefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -89,6 +105,10 @@ func TestLaunchBrowserEmptyHostDefaultsToLocalhost(t *testing.T) { //nolint:para
 
 func TestLaunchBrowserExplicitHostUsed(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -108,6 +128,10 @@ func TestLaunchBrowserExplicitHostUsed(t *testing.T) { //nolint:paralleltest // 
 
 func TestLaunchBrowserTLSUsesHTTPS(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -128,6 +152,10 @@ func TestLaunchBrowserTLSUsesHTTPS(t *testing.T) { //nolint:paralleltest // cann
 
 func TestLaunchBrowserTLSAndEmptyHostDefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -148,6 +176,10 @@ func TestLaunchBrowserTLSAndEmptyHostDefaultsToLocalhost(t *testing.T) { //nolin
 
 func TestLaunchBrowserWildcard0000DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -164,6 +196,10 @@ func TestLaunchBrowserWildcard0000DefaultsToLocalhost(t *testing.T) { //nolint:p
 
 func TestLaunchBrowserWildcardIPv6DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -180,6 +216,10 @@ func TestLaunchBrowserWildcardIPv6DefaultsToLocalhost(t *testing.T) { //nolint:p
 
 func TestLaunchBrowserWildcardBracketedIPv6DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -196,6 +236,10 @@ func TestLaunchBrowserWildcardBracketedIPv6DefaultsToLocalhost(t *testing.T) { /
 
 func TestLaunchBrowserIPv6LoopbackWrappedInBrackets(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{
@@ -212,6 +256,10 @@ func TestLaunchBrowserIPv6LoopbackWrappedInBrackets(t *testing.T) { //nolint:par
 
 func TestLaunchBrowserBracketedIPv6LoopbackStrippedThenRewrapped(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
+	original := cmdExecutor
+
+	t.Cleanup(func() { cmdExecutor = original })
+
 	cmdExecutor = mockCmdExecutor
 
 	cfg := &config.Config{

--- a/cmd/app/browser_test.go
+++ b/cmd/app/browser_test.go
@@ -3,10 +3,13 @@
 package main
 
 import (
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+
+	"github.com/device-management-toolkit/console/config"
 )
 
 type MockCommandExecutor struct {
@@ -19,11 +22,24 @@ func (m *MockCommandExecutor) Execute(name string, arg ...string) error {
 	return args.Error(0)
 }
 
+// expectedOpenBrowserArgs returns the cmd and args openBrowser will use for the
+// current OS, mirroring the switch statement in openBrowser.
+func expectedOpenBrowserArgs(url string) (cmd string, args []string) {
+	switch runtime.GOOS {
+	case "darwin":
+		return "open", []string{url}
+	case "windows":
+		return "cmd", []string{windowsCmdFlag, windowsCmdStart, url}
+	default:
+		return "xdg-open", []string{url}
+	}
+}
+
 func TestOpenBrowserWindows(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
 	mockCmdExecutor := new(MockCommandExecutor)
 	cmdExecutor = mockCmdExecutor
 
-	mockCmdExecutor.On("Execute", "cmd", []string{"/c", "start", "http://localhost:8080"}).Return(nil)
+	mockCmdExecutor.On("Execute", "cmd", []string{windowsCmdFlag, windowsCmdStart, "http://localhost:8080"}).Return(nil)
 
 	err := openBrowser("http://localhost:8080", "windows")
 	assert.NoError(t, err)
@@ -49,5 +65,163 @@ func TestOpenBrowserLinux(t *testing.T) { //nolint:paralleltest // cannot have s
 
 	err := openBrowser("http://localhost:8080", "ubuntu")
 	assert.NoError(t, err)
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserEmptyHostDefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{
+			Host: "",
+			Port: "8181",
+		},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://localhost:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserExplicitHostUsed(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{
+			Host: "192.168.1.100",
+			Port: "8181",
+		},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://192.168.1.100:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserTLSUsesHTTPS(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{
+			Host: "myserver",
+			Port: "8443",
+			TLS:  config.TLS{Enabled: true},
+		},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("https://myserver:8443")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserTLSAndEmptyHostDefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{
+			Host: "",
+			Port: "8443",
+			TLS:  config.TLS{Enabled: true},
+		},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("https://localhost:8443")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserWildcard0000DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{Host: "0.0.0.0", Port: "8181"},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://localhost:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserWildcardIPv6DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{Host: "::", Port: "8181"},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://localhost:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserWildcardBracketedIPv6DefaultsToLocalhost(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{Host: "[::]", Port: "8181"},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://localhost:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserIPv6LoopbackWrappedInBrackets(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{Host: "::1", Port: "8181"},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://[::1]:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
+	mockCmdExecutor.AssertExpectations(t)
+}
+
+func TestLaunchBrowserBracketedIPv6LoopbackStrippedThenRewrapped(t *testing.T) { //nolint:paralleltest // cannot have simultaneous tests modifying executor.
+	mockCmdExecutor := new(MockCommandExecutor)
+	cmdExecutor = mockCmdExecutor
+
+	cfg := &config.Config{
+		HTTP: config.HTTP{Host: "[::1]", Port: "8181"},
+	}
+
+	cmd, args := expectedOpenBrowserArgs("http://[::1]:8181")
+	mockCmdExecutor.On("Execute", cmd, args).Return(nil)
+
+	launchBrowser(cfg)
+
 	mockCmdExecutor.AssertExpectations(t)
 }

--- a/cmd/app/hostnorm.go
+++ b/cmd/app/hostnorm.go
@@ -1,0 +1,37 @@
+package main
+
+const (
+	addrWildcardIPv4 = "0.0.0.0"
+	addrWildcardIPv6 = "::"
+	addrLocalhost    = "localhost"
+)
+
+// unbracketHost strips a single pair of surrounding brackets from a literal
+// IPv6 host so net.JoinHostPort doesn't double-wrap (e.g. "[::1]" → "::1").
+func unbracketHost(host string) string {
+	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
+		return host[1 : len(host)-1]
+	}
+
+	return host
+}
+
+// isWildcardListenHost reports whether host is an all-interfaces bind address
+// (empty string, 0.0.0.0, ::, or their bracketed forms). Brackets are stripped
+// before comparison so both "::" and "[::]" are recognized uniformly.
+func isWildcardListenHost(host string) bool {
+	host = unbracketHost(host)
+
+	return host == "" || host == addrWildcardIPv4 || host == addrWildcardIPv6
+}
+
+// navigableHost returns a host suitable for constructing a browser URL: it
+// strips surrounding IPv6 brackets and maps wildcard bind addresses to
+// "localhost".
+func navigableHost(host string) string {
+	if isWildcardListenHost(host) {
+		return addrLocalhost
+	}
+
+	return unbracketHost(host)
+}

--- a/cmd/app/hostnorm_test.go
+++ b/cmd/app/hostnorm_test.go
@@ -1,0 +1,83 @@
+package main
+
+import "testing"
+
+func TestUnbracketHost(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		"[::1]":     "::1",
+		"[fe80::1]": "fe80::1",
+		"[]":        "",
+		"::1":       "::1",
+		"localhost": "localhost",
+		"":          "",
+		"[":         "[",
+		"]":         "]",
+	}
+
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			if got := unbracketHost(in); got != want {
+				t.Errorf("unbracketHost(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}
+
+func TestIsWildcardListenHost(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]bool{
+		"":          true,
+		"0.0.0.0":   true,
+		"::":        true,
+		"[::]":      true,
+		"localhost": false,
+		"127.0.0.1": false,
+		"10.0.0.1":  false,
+	}
+
+	for host, want := range tests {
+		host, want := host, want
+		t.Run(host, func(t *testing.T) {
+			t.Parallel()
+
+			if got := isWildcardListenHost(host); got != want {
+				t.Errorf("isWildcardListenHost(%q) = %v, want %v", host, got, want)
+			}
+		})
+	}
+}
+
+func TestNavigableHost(t *testing.T) {
+	t.Parallel()
+
+	tests := map[string]string{
+		// Wildcard addresses map to localhost.
+		"":        "localhost",
+		"0.0.0.0": "localhost",
+		"::":      "localhost",
+		"[::]":    "localhost",
+		// Specific addresses are returned as-is (brackets stripped for IPv6).
+		"::1":         "::1",
+		"[::1]":       "::1",
+		"127.0.0.1":   "127.0.0.1",
+		"192.168.1.1": "192.168.1.1",
+		"myserver":    "myserver",
+	}
+
+	for in, want := range tests {
+		in, want := in, want
+		t.Run(in, func(t *testing.T) {
+			t.Parallel()
+
+			if got := navigableHost(in); got != want {
+				t.Errorf("navigableHost(%q) = %q, want %q", in, got, want)
+			}
+		})
+	}
+}

--- a/cmd/app/tray.go
+++ b/cmd/app/tray.go
@@ -102,23 +102,13 @@ func listenURLs(cfg *config.Config) []string {
 	return urls
 }
 
-// unbracketHost strips a single pair of surrounding brackets from a literal IPv6
-// host so net.JoinHostPort doesn't double-wrap (e.g. "[::1]" → "::1").
-func unbracketHost(host string) string {
-	if len(host) >= 2 && host[0] == '[' && host[len(host)-1] == ']' {
-		return host[1 : len(host)-1]
-	}
-
-	return host
-}
-
 // listenHosts always returns at least one entry ("localhost") so listenURLs[0] is safe.
 func listenHosts(cfgHost string) []string {
 	if !isWildcardListenHost(cfgHost) {
 		return []string{cfgHost}
 	}
 
-	hosts := []string{"localhost"}
+	hosts := []string{addrLocalhost}
 
 	ifaces, err := net.Interfaces()
 	if err != nil {
@@ -193,8 +183,4 @@ func isVirtualInterfaceName(name string) bool {
 	}
 
 	return false
-}
-
-func isWildcardListenHost(host string) bool {
-	return host == "" || host == "0.0.0.0" || host == "::" || host == "[::]"
 }

--- a/cmd/app/tray_test.go
+++ b/cmd/app/tray_test.go
@@ -8,31 +8,6 @@ import (
 	"github.com/device-management-toolkit/console/config"
 )
 
-func TestIsWildcardListenHost(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]bool{
-		"":          true,
-		"0.0.0.0":   true,
-		"::":        true,
-		"[::]":      true,
-		"localhost": false,
-		"127.0.0.1": false,
-		"10.0.0.1":  false,
-	}
-
-	for host, want := range tests {
-		host, want := host, want
-		t.Run(host, func(t *testing.T) {
-			t.Parallel()
-
-			if got := isWildcardListenHost(host); got != want {
-				t.Errorf("isWildcardListenHost(%q) = %v, want %v", host, got, want)
-			}
-		})
-	}
-}
-
 func TestListenURLsBracketedIPv6(t *testing.T) {
 	t.Parallel()
 
@@ -51,32 +26,6 @@ func TestListenURLsBracketedIPv6(t *testing.T) {
 
 	if want := "https://[::1]:8181"; urls[0] != want {
 		t.Errorf("listenURLs[0] = %q, want %q", urls[0], want)
-	}
-}
-
-func TestUnbracketHost(t *testing.T) {
-	t.Parallel()
-
-	tests := map[string]string{
-		"[::1]":     "::1",
-		"[fe80::1]": "fe80::1",
-		"[]":        "",
-		"::1":       "::1",
-		"localhost": "localhost",
-		"":          "",
-		"[":         "[",
-		"]":         "]",
-	}
-
-	for in, want := range tests {
-		in, want := in, want
-		t.Run(in, func(t *testing.T) {
-			t.Parallel()
-
-			if got := unbracketHost(in); got != want {
-				t.Errorf("unbracketHost(%q) = %q, want %q", in, got, want)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Following fixes done:
1. Default browser launch always opens to https://localhost:8181 even with HTTP_HOST is set to a valid host
2. Default host to localhost in launchBrowser when the configured value is empty.
3. Update README lint commands to use --pull always so Docker re-checks Docker Hub on every invocation instead of reusing a stale cached image.

Here's the behavior before fix:

HTTP_PORT=8181 HTTP_HOST=10.190.213.14  AUTH_ADMIN_USERNAME=admin AUTH_ADMIN_PASSWORD=P@ssw0rd APP_ENCRYPTION_KEY="aB3dE5gH7jK9mN1pQ2rS4tU6wX8zC0vB" ./console_linux_amd64

Will launch browser with

<img width="1413" height="33" alt="image" src="https://github.com/user-attachments/assets/bcf6ce86-3723-4936-a8b6-9bb92bed8a8d" />

Post Fix browser is launched with

<img width="687" height="40" alt="image" src="https://github.com/user-attachments/assets/1b31504d-ff46-4788-9ac2-9ef7ecd1640f" />




