### PR TITLE
feat: implement control mode extension for kvm and sol

### DIFF
--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 
 	amtBoot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
 	cimBoot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/boot"
 	wsmanClient "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/client"
 	optin "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
@@ -47,6 +48,7 @@ const (
 	serialConsoleMode       = "sol"
 	redirectionWebSocketURI = "/relay/webrelay.ashx"
 	controlModeACM          = "ACM"
+	controlModeCCM          = "CCM"
 	userConsentNotRequired  = "NotRequired"
 	statusPendingConsent    = "PendingConsent"
 	statusError             = "Error"
@@ -900,13 +902,15 @@ func (r *WsmanComputerSystemRepo) GetByID(ctx context.Context, systemID string) 
 		return system, nil
 	}
 
-	system.GraphicalConsole = r.buildGraphicalConsole(device.UseTLS, featuresV2)
-	system.SerialConsole = r.buildSerialConsole(systemID, featuresV2)
+	controlMode := r.getAMTControlMode(ctx, systemID)
+
+	system.GraphicalConsole = r.buildGraphicalConsole(device.UseTLS, featuresV2, controlMode)
+	system.SerialConsole = r.buildSerialConsole(systemID, featuresV2, controlMode)
 
 	return system, nil
 }
 
-func (r *WsmanComputerSystemRepo) buildGraphicalConsole(useTLS bool, featuresV2 dtov2.Features) *redfishv1.ComputerSystemHostGraphicalConsole {
+func (r *WsmanComputerSystemRepo) buildGraphicalConsole(useTLS bool, featuresV2 dtov2.Features, controlMode string) *redfishv1.ComputerSystemHostGraphicalConsole {
 	serviceEnabled := featuresV2.EnableKVM
 
 	var connectTypes []string
@@ -933,8 +937,7 @@ func (r *WsmanComputerSystemRepo) buildGraphicalConsole(useTLS bool, featuresV2 
 	oemExt := &redfishv1.ComputerSystemHostGraphicalConsoleOEM{
 		Intel: &redfishv1.ComputerSystemHostGraphicalConsoleIntel{
 			AMT: &redfishv1.ComputerSystemHostGraphicalConsoleAMT{
-				// Planned follow-up: query AMT_GeneralSettings from WS-Man to get actual control mode.
-				ControlMode: controlModeACM,
+				ControlMode: controlMode,
 				KVMStatus:   kvmStatus,
 				// Planned follow-up: query CIM_KVMRedirectionSAP and IPS_OptInService for actual user consent status.
 				UserConsentStatus: userConsentNotRequired,
@@ -983,7 +986,7 @@ func determineKVMStatus(enableKVM, kvmAvailable bool, userConsent string, optInS
 	return StateEnabled
 }
 
-func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2 dtov2.Features) *redfishv1.ComputerSystemHostSerialConsole {
+func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2 dtov2.Features, controlMode string) *redfishv1.ComputerSystemHostSerialConsole {
 	serviceEnabled := featuresV2.EnableSOL
 	maxConcurrentSessions := int64(1)
 	interactive := true
@@ -1001,8 +1004,7 @@ func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2
 	oemExt := &redfishv1.ComputerSystemHostSerialConsoleOEM{
 		Intel: &redfishv1.ComputerSystemHostSerialConsoleIntel{
 			AMT: &redfishv1.ComputerSystemHostSerialConsoleAMT{
-				// Planned follow-up: query AMT_GeneralSettings from WS-Man to get actual control mode.
-				ControlMode: controlModeACM,
+				ControlMode: controlMode,
 				SOLStatus:   solStatus,
 				// Planned follow-up: query AMT_RedirectionService and IPS_OptInService for actual user consent status.
 				UserConsentStatus: userConsentNotRequired,
@@ -1052,6 +1054,32 @@ func determineSOLStatus(enableSOL, solAvailable bool, userConsent string, optInS
 	}
 
 	return StateEnabled
+}
+
+func (r *WsmanComputerSystemRepo) getAMTControlMode(ctx context.Context, systemID string) string {
+	version, _, err := r.usecase.GetVersion(ctx, systemID)
+	if err != nil {
+		r.log.Warn("Failed to retrieve AMT version for control mode", "systemID", systemID, "error", err)
+
+		return ""
+	}
+
+	return mapControlModeFromVersion(version)
+}
+
+func mapControlModeFromVersion(version dto.Version) string {
+	return mapProvisioningModeToControlMode(version.AMTSetupAndConfigurationService.Response.ProvisioningMode)
+}
+
+func mapProvisioningModeToControlMode(mode setupandconfiguration.ProvisioningModeValue) string {
+	switch mode {
+	case setupandconfiguration.ClientControlMode:
+		return controlModeCCM
+	case setupandconfiguration.AdminControlMode:
+		return controlModeACM
+	default:
+		return ""
+	}
 }
 
 // UpdateGraphicalConsoleServiceEnabled updates KVM enabled state through the existing devices feature flow.

--- a/redfish/internal/usecase/wsman_repo_test.go
+++ b/redfish/internal/usecase/wsman_repo_test.go
@@ -9,17 +9,150 @@ import (
 
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/redirection"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
 	cimBoot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/boot"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/kvm"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/software"
 	optin "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/ips/optin"
 
 	"github.com/device-management-toolkit/console/internal/entity"
+	dto "github.com/device-management-toolkit/console/internal/entity/dto/v1"
 	dtov2 "github.com/device-management-toolkit/console/internal/entity/dto/v2"
 	"github.com/device-management-toolkit/console/internal/mocks"
 	"github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/pkg/logger"
 	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
 )
+
+func TestMapProvisioningModeToControlMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		mode setupandconfiguration.ProvisioningModeValue
+		want string
+	}{
+		{name: "admin mode maps to ACM", mode: setupandconfiguration.AdminControlMode, want: controlModeACM},
+		{name: "client mode maps to CCM", mode: setupandconfiguration.ClientControlMode, want: controlModeCCM},
+		{name: "unknown mode omitted", mode: 999, want: ""},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapProvisioningModeToControlMode(tt.mode)
+			if got != tt.want {
+				t.Fatalf("mapProvisioningModeToControlMode() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMapControlModeFromVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version dto.Version
+		want    string
+	}{
+		{
+			name:    "admin mode from version",
+			version: dto.Version{AMTSetupAndConfigurationService: dto.SetupAndConfigurationServiceResponses{Response: dto.SetupAndConfigurationServiceResponse{ProvisioningMode: setupandconfiguration.AdminControlMode}}},
+			want:    controlModeACM,
+		},
+		{
+			name:    "client mode from version",
+			version: dto.Version{AMTSetupAndConfigurationService: dto.SetupAndConfigurationServiceResponses{Response: dto.SetupAndConfigurationServiceResponse{ProvisioningMode: setupandconfiguration.ClientControlMode}}},
+			want:    controlModeCCM,
+		},
+		{
+			name:    "unknown mode omitted",
+			version: dto.Version{},
+			want:    "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := mapControlModeFromVersion(tt.version)
+			if got != tt.want {
+				t.Fatalf("mapControlModeFromVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetAMTControlMode(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	tests := []struct {
+		name     string
+		setup    func(*testing.T, *mocks.MockDeviceManagementRepository, *mocks.MockWSMAN, *mocks.MockManagement, *entity.Device)
+		wantMode string
+	}{
+		{
+			name: "client control mode from version",
+			setup: func(t *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement, device *entity.Device) {
+				t.Helper()
+
+				repo.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil)
+				wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil)
+				management.EXPECT().GetAMTVersion().Return([]software.SoftwareIdentity{}, nil)
+				management.EXPECT().GetSetupAndConfiguration().Return([]setupandconfiguration.SetupAndConfigurationServiceResponse{{ProvisioningMode: setupandconfiguration.ClientControlMode}}, nil)
+			},
+			wantMode: controlModeCCM,
+		},
+		{
+			name: "failure returns empty control mode",
+			setup: func(t *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement, device *entity.Device) {
+				t.Helper()
+
+				repo.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil)
+				wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil)
+				management.EXPECT().GetAMTVersion().Return(nil, errors.New("boom"))
+			},
+			wantMode: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+			wsmanMock := mocks.NewMockWSMAN(ctrl)
+			wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+			redirectionMock := mocks.NewMockRedirection(ctrl)
+			management := mocks.NewMockManagement(ctrl)
+
+			uc := devices.New(repoMock, wsmanMock, redirectionMock, logger.New("error"), mocks.MockCrypto{})
+			repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+			tt.setup(t, repoMock, wsmanMock, management, device)
+
+			got := repo.getAMTControlMode(context.Background(), device.GUID)
+			if got != tt.wantMode {
+				t.Fatalf("getAMTControlMode() = %q, want %q", got, tt.wantMode)
+			}
+		})
+	}
+}
 
 func TestDetermineKVMStatus(t *testing.T) {
 	t.Parallel()
@@ -228,7 +361,7 @@ func TestBuildGraphicalConsole(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := repo.buildGraphicalConsole(tt.useTLS, tt.features)
+			got := repo.buildGraphicalConsole(tt.useTLS, tt.features, controlModeACM)
 			assertGraphicalConsole(t, got, tt.wantEnabled, tt.wantConnTypes, tt.wantPort, tt.wantKVMStatus)
 		})
 	}
@@ -674,7 +807,7 @@ func TestBuildSerialConsole(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := repo.buildSerialConsole(tt.systemID, tt.features)
+			got := repo.buildSerialConsole(tt.systemID, tt.features, controlModeACM)
 			assertSerialConsole(t, got, tt.wantEnabled, tt.wantURI, tt.wantSOLStatus)
 		})
 	}


### PR DESCRIPTION
Fetch AMT control mode from version data and populate KVM and SOL OEM extension.
Input and output:
ACM:
```
curl -u "standalone:G@ppm0ym" http://localhost:8181/redfish/v1/Systems/32bcccf9-9a56-0db3-48d6-48210b50d7ea | jq .GraphicalConsole
{
  "ConnectTypesSupported": [
    "KVMIP"
  ],
  "Oem": {
    "Intel": {
      "AMT": {
        "ControlMode": "ACM",
        "KVMStatus": "Enabled",
        "UserConsentStatus": "NotRequired"
      }
    }
  },
  "Port": 16994,
  "ServiceEnabled": true
}
```
CCM:

 ```
 curl -u "standalone:G@ppm0ym" http://localhost:8181/redfish/v1/Systems/32bcccf9-9a56-0db3-48d6-48210b50d7ea | jq .GraphicalConsole
{
  "ConnectTypesSupported": [
    "KVMIP"
  ],
  "Oem": {
    "Intel": {
      "AMT": {
        "ControlMode": "CCM",
        "KVMStatus": "Disabled",
        "UserConsentStatus": "NotRequired"
      }
    }
  },
  "Port": 16994,
  "ServiceEnabled": false
}
```
CCM with KVM Enabled:

```curl -u "standalone:G@ppm0ym" http://localhost:8181/redfish/v1/Systems/32bcccf9-9a56-0db3-48d6-48210b50d7ea | jq .SerialConsole  
{
  "MaxConcurrentSessions": 1,
  "Oem": {
    "Intel": {
      "AMT": {
        "ControlMode": "CCM",
        "SOLStatus": "PendingConsent",
        "UserConsentStatus": "NotRequired"
      }
    }
  },
  "WebSocket": {
    "ConsoleURI": "ws://localhost:8181/relay/webrelay.ashx?host=32bcccf9-9a56-0db3-48d6-48210b50d7ea&mode=sol",
    "Interactive": true,
    "ServiceEnabled": true
  }
}
```