### PR TITLE
fix: allow AUTH_ env vars for OAuth Configuration beyond just config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -99,18 +99,19 @@ type (
 		RedirectionJWTExpiration time.Duration `yaml:"redirectionJWTExpiration" env:"AUTH_REDIRECTION_JWT_EXPIRATION"`
 		ClientID                 string        `yaml:"clientId" env:"AUTH_CLIENT_ID"`
 		Issuer                   string        `yaml:"issuer" env:"AUTH_ISSUER"`
+		TLSSkipVerify            bool          `yaml:"tlsSkipVerify" env:"AUTH_TLS_SKIP_VERIFY"`
 		UI                       UIAuthConfig  `yaml:"ui"`
 	}
 
 	// UIAuthConfig -.
 	UIAuthConfig struct {
-		ClientID                          string `yaml:"clientId"`
-		Issuer                            string `yaml:"issuer"`
-		RedirectURI                       string `yaml:"redirectUri"`
-		Scope                             string `yaml:"scope"`
-		ResponseType                      string `yaml:"responseType"`
-		RequireHTTPS                      bool   `yaml:"requireHttps"`
-		StrictDiscoveryDocumentValidation bool   `yaml:"strictDiscoveryDocumentValidation"`
+		ClientID                          string `yaml:"clientId" env:"AUTH_UI_CLIENT_ID"`
+		Issuer                            string `yaml:"issuer" env:"AUTH_UI_ISSUER"`
+		RedirectURI                       string `yaml:"redirectUri" env:"AUTH_UI_REDIRECT_URI"`
+		Scope                             string `yaml:"scope" env:"AUTH_UI_SCOPE"`
+		ResponseType                      string `yaml:"responseType" env:"AUTH_UI_RESPONSE_TYPE"`
+		RequireHTTPS                      bool   `yaml:"requireHttps" env:"AUTH_UI_REQUIRE_HTTPS"`
+		StrictDiscoveryDocumentValidation bool   `yaml:"strictDiscoveryDocumentValidation" env:"AUTH_UI_STRICT_DISCOVERY"`
 	}
 
 	// UI -.

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -34,7 +35,20 @@ func NewLoginRoute(configData *config.Config) *LoginRoute {
 	}
 
 	if config.ConsoleConfig.ClientID != "" {
-		provider, err := oidc.NewProvider(context.Background(), config.ConsoleConfig.Issuer)
+		ctx := context.Background()
+
+		if config.ConsoleConfig.TLSSkipVerify {
+			transport, _ := http.DefaultTransport.(*http.Transport)
+			transport = transport.Clone()
+			transport.TLSClientConfig = &tls.Config{
+				MinVersion:         tls.VersionTLS12,
+				InsecureSkipVerify: true, //nolint:gosec // operator opted in via auth.tlsSkipVerify to trust self-signed IdP
+			}
+
+			ctx = oidc.ClientContext(ctx, &http.Client{Transport: transport})
+		}
+
+		provider, err := oidc.NewProvider(ctx, config.ConsoleConfig.Issuer)
 		if err != nil {
 			return nil
 		}

--- a/internal/controller/httpapi/v1/login_test.go
+++ b/internal/controller/httpapi/v1/login_test.go
@@ -1,0 +1,85 @@
+package v1
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/device-management-toolkit/console/config"
+)
+
+// oidcDiscoveryServer spins up a TLS test server that serves the minimum
+// OpenID Connect discovery document that go-oidc requires. The issuer field
+// in the response must match the server URL, otherwise NewProvider fails.
+func oidcDiscoveryServer(t *testing.T) *httptest.Server {
+	t.Helper()
+
+	mux := http.NewServeMux()
+
+	srv := httptest.NewTLSServer(mux)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                                srv.URL,
+			"authorization_endpoint":                srv.URL + "/authorize",
+			"token_endpoint":                        srv.URL + "/token",
+			"jwks_uri":                              srv.URL + "/jwks",
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+		})
+	})
+
+	t.Cleanup(srv.Close)
+
+	return srv
+}
+
+// TestNewLoginRoute mutates the package-level config.ConsoleConfig, so its
+// subtests run sequentially to avoid racing the global with other tests in
+// this package that read it.
+//
+//nolint:paralleltest // shared global config.ConsoleConfig
+func TestNewLoginRoute(t *testing.T) {
+	prev := config.ConsoleConfig
+
+	t.Cleanup(func() { config.ConsoleConfig = prev })
+
+	t.Run("no ClientID returns route with nil Verifier", func(t *testing.T) {
+		config.ConsoleConfig = &config.Config{}
+
+		lr := NewLoginRoute(&config.Config{})
+
+		require.NotNil(t, lr)
+		require.Nil(t, lr.Verifier)
+	})
+
+	t.Run("TLSSkipVerify trusts self-signed IdP", func(t *testing.T) {
+		srv := oidcDiscoveryServer(t)
+
+		config.ConsoleConfig = &config.Config{}
+		config.ConsoleConfig.ClientID = "test-client"
+		config.ConsoleConfig.Issuer = srv.URL
+		config.ConsoleConfig.TLSSkipVerify = true
+
+		lr := NewLoginRoute(&config.Config{})
+
+		require.NotNil(t, lr, "expected provider discovery to succeed with TLSSkipVerify=true")
+		require.NotNil(t, lr.Verifier)
+	})
+
+	t.Run("default TLS verify rejects self-signed IdP", func(t *testing.T) {
+		srv := oidcDiscoveryServer(t)
+
+		config.ConsoleConfig = &config.Config{}
+		config.ConsoleConfig.ClientID = "test-client"
+		config.ConsoleConfig.Issuer = srv.URL
+		config.ConsoleConfig.TLSSkipVerify = false
+
+		lr := NewLoginRoute(&config.Config{})
+
+		require.Nil(t, lr, "expected provider discovery to fail against self-signed cert without skip verify")
+	})
+}


### PR DESCRIPTION
ref: https://github.com/device-management-toolkit/console/issues/842