### PR TITLE
feat(api): expose server features endpoint for CIRA tab toggle

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -8,6 +8,51 @@
 	},
 	"item": [
 		{
+			"name": "Server",
+			"item": [
+				{
+					"name": "Get Server Features",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Response contains ciraEnabled boolean\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData).to.have.property(\"ciraEnabled\");\r",
+									"    pm.expect(jsonData.ciraEnabled).to.be.a(\"boolean\");\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/server/features",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"server",
+								"features"
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
 			"name": "AMT",
 			"item": [
 				{

--- a/internal/controller/httpapi/router.go
+++ b/internal/controller/httpapi/router.go
@@ -70,6 +70,7 @@ func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases, cfg 
 		v1.NewDeviceRoutes(h2, t.Devices, l)
 		v1.NewAmtRoutes(h2, t.Devices, t.AMTExplorer, t.Exporter, l)
 		v1.NewCIRACertRoutes(h2, l)
+		v1.NewServerRoutes(h2, cfg)
 	}
 
 	h := protected.Group("/v1/admin")

--- a/internal/controller/httpapi/v1/server.go
+++ b/internal/controller/httpapi/v1/server.go
@@ -1,0 +1,32 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/config"
+	dto "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+)
+
+type serverRoutes struct {
+	config *config.Config
+}
+
+// NewServerRoutes registers server-level capability endpoints. These expose how
+// Console was started so clients can adapt their UI (e.g. show/hide the CIRA tab).
+func NewServerRoutes(handler *gin.RouterGroup, cfg *config.Config) {
+	r := &serverRoutes{config: cfg}
+
+	h := handler.Group("/server")
+	{
+		h.GET("features", r.getFeatures)
+	}
+}
+
+// getFeatures returns the server-level feature flags.
+func (r *serverRoutes) getFeatures(c *gin.Context) {
+	c.JSON(http.StatusOK, dto.ServerFeatures{
+		CIRAEnabled: !r.config.DisableCIRA,
+	})
+}

--- a/internal/controller/httpapi/v1/server_test.go
+++ b/internal/controller/httpapi/v1/server_test.go
@@ -1,0 +1,71 @@
+package v1
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/device-management-toolkit/console/config"
+	dto "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+)
+
+func serverTestEngine(t *testing.T, disableCIRA bool) *gin.Engine {
+	t.Helper()
+
+	cfg := &config.Config{App: config.App{DisableCIRA: disableCIRA}}
+
+	engine := gin.New()
+	group := engine.Group("/api/v1")
+
+	NewServerRoutes(group, cfg)
+
+	return engine
+}
+
+func TestServerFeatures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		disableCIRA     bool
+		wantCIRAEnabled bool
+	}{
+		{
+			name:            "CIRA enabled when not disabled",
+			disableCIRA:     false,
+			wantCIRAEnabled: true,
+		},
+		{
+			name:            "CIRA disabled",
+			disableCIRA:     true,
+			wantCIRAEnabled: false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			engine := serverTestEngine(t, tt.disableCIRA)
+
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/server/features", http.NoBody)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusOK, w.Code)
+
+			var features dto.ServerFeatures
+			require.NoError(t, json.Unmarshal(w.Body.Bytes(), &features))
+			require.Equal(t, tt.wantCIRAEnabled, features.CIRAEnabled)
+		})
+	}
+}

--- a/internal/controller/openapi/adapter.go
+++ b/internal/controller/openapi/adapter.go
@@ -73,6 +73,9 @@ func (f *FuegoAdapter) RegisterRoutes() {
 
 	// Device Management
 	f.RegisterDeviceManagementRoutes()
+
+	// Server features
+	f.RegisterServerRoutes()
 }
 
 // Generates OpenAPI specification as JSON.

--- a/internal/controller/openapi/server.go
+++ b/internal/controller/openapi/server.go
@@ -1,0 +1,20 @@
+package openapi
+
+import (
+	"github.com/go-fuego/fuego"
+
+	dto "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+)
+
+func (f *FuegoAdapter) RegisterServerRoutes() {
+	fuego.Get(f.server, "/api/v1/server/features", f.getServerFeatures,
+		fuego.OptionTags("Server"),
+		fuego.OptionSummary("Get Server Features"),
+		fuego.OptionDescription("Retrieve server-level capability flags so clients can adapt their UI (e.g. show or hide the CIRA tab)"),
+		protectedRouteOptions(),
+	)
+}
+
+func (f *FuegoAdapter) getServerFeatures(_ fuego.ContextNoBody) (dto.ServerFeatures, error) {
+	return dto.ServerFeatures{}, nil
+}

--- a/internal/entity/dto/v1/server.go
+++ b/internal/entity/dto/v1/server.go
@@ -1,0 +1,11 @@
+package dto
+
+type (
+	// ServerFeatures reports server-level capability flags so clients (e.g. the
+	// Sample Web UI) can toggle features that depend on how Console was started.
+	// New flags should be added here as additional fields rather than via a new
+	// endpoint.
+	ServerFeatures struct {
+		CIRAEnabled bool `json:"ciraEnabled" example:"true"`
+	}
+)


### PR DESCRIPTION
Add GET /api/v1/server/features returning an extensible capabilities object so clients (e.g. the Sample Web UI) can adapt their UI to how Console was started. The first flag, ciraEnabled, is derived from the existing APP_DISABLE_CIRA setting and lets the UI show or hide the CIRA tab.

Updates the Gin handler, the Fuego/OpenAPI declaration, and the MPS Postman collection in lock-step.

Contributes to https://github.com/device-management-toolkit/sample-web-ui/issues/3200