### PR TITLE
feat(cira): reject CIRA endpoints and profiles when CIRA is disabled

### DIFF
--- a/internal/controller/httpapi/router.go
+++ b/internal/controller/httpapi/router.go
@@ -69,14 +69,14 @@ func NewRouter(handler *gin.Engine, l logger.Interface, t usecase.Usecases, cfg 
 	{
 		v1.NewDeviceRoutes(h2, t.Devices, l)
 		v1.NewAmtRoutes(h2, t.Devices, t.AMTExplorer, t.Exporter, l)
-		v1.NewCIRACertRoutes(h2, l)
+		v1.NewCIRACertRoutes(h2, l, cfg)
 		v1.NewServerRoutes(h2, cfg)
 	}
 
 	h := protected.Group("/v1/admin")
 	{
 		v1.NewDomainRoutes(h, t.Domains, l)
-		v1.NewCIRAConfigRoutes(h, t.CIRAConfigs, l)
+		v1.NewCIRAConfigRoutes(h, t.CIRAConfigs, l, cfg)
 		v1.NewProfileRoutes(h, t.Profiles, l)
 		v1.NewWirelessConfigRoutes(h, t.WirelessProfiles, l)
 		v1.NewIEEE8021xConfigRoutes(h, t.IEEE8021xProfiles, l)

--- a/internal/controller/httpapi/v1/ciracert.go
+++ b/internal/controller/httpapi/v1/ciracert.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
 
@@ -31,26 +32,19 @@ type ciraCertRoutes struct {
 	certReader CertReader
 }
 
-func NewCIRACertRoutes(handler *gin.RouterGroup, l logger.Interface) {
-	r := &ciraCertRoutes{
-		l:          l,
-		certReader: &FileCertReader{Path: "config/root_cert.pem"},
-	}
-
-	h := handler.Group("/ciracert")
-	{
-		h.GET("", r.getCIRACert)
-	}
+func NewCIRACertRoutes(handler *gin.RouterGroup, l logger.Interface, cfg *config.Config) {
+	NewCIRACertRoutesWithReader(handler, l, &FileCertReader{Path: "config/root_cert.pem"}, cfg)
 }
 
 // NewCIRACertRoutesWithReader creates routes with a custom cert reader (for testing).
-func NewCIRACertRoutesWithReader(handler *gin.RouterGroup, l logger.Interface, certReader CertReader) {
+func NewCIRACertRoutesWithReader(handler *gin.RouterGroup, l logger.Interface, certReader CertReader, cfg *config.Config) {
 	r := &ciraCertRoutes{
 		l:          l,
 		certReader: certReader,
 	}
 
 	h := handler.Group("/ciracert")
+	h.Use(ciraDisabledMiddleware(cfg.DisableCIRA))
 	{
 		h.GET("", r.getCIRACert)
 	}

--- a/internal/controller/httpapi/v1/ciracert_test.go
+++ b/internal/controller/httpapi/v1/ciracert_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
 
@@ -32,7 +33,7 @@ func ciraCertTestWithReader(t *testing.T, reader CertReader) *gin.Engine {
 	engine := gin.New()
 	handler := engine.Group("/api/v1/admin")
 
-	NewCIRACertRoutesWithReader(handler, log, reader)
+	NewCIRACertRoutesWithReader(handler, log, reader, &config.Config{})
 
 	return engine
 }
@@ -231,6 +232,28 @@ func TestCIRACertRoutes_ReadError(t *testing.T) {
 
 	require.Equal(t, http.StatusInternalServerError, w.Code)
 	require.Contains(t, w.Body.String(), "Failed to read certificate file")
+}
+
+func TestCIRACertRoutes_DisabledReturns404(t *testing.T) {
+	t.Parallel()
+
+	log := logger.New("error")
+
+	engine := gin.New()
+	handler := engine.Group("/api/v1/admin")
+
+	// Reader errors if reached — the guard must reject first.
+	reader := &mockCertReader{data: nil, err: errors.New("should not be read")}
+	NewCIRACertRoutesWithReader(handler, log, reader, &config.Config{App: config.App{DisableCIRA: true}})
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/admin/ciracert", http.NoBody)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusNotFound, w.Code)
+	require.JSONEq(t, `{"error":"CIRA is disabled on this instance"}`, w.Body.String())
 }
 
 // TestCIRACertRoutes_Coverage ensures all code paths are tested.

--- a/internal/controller/httpapi/v1/ciraconfigs.go
+++ b/internal/controller/httpapi/v1/ciraconfigs.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 	"github.com/device-management-toolkit/console/internal/usecase/ciraconfigs"
 	"github.com/device-management-toolkit/console/pkg/logger"
@@ -15,10 +16,11 @@ type ciraConfigRoutes struct {
 	l    logger.Interface
 }
 
-func NewCIRAConfigRoutes(handler *gin.RouterGroup, t ciraconfigs.Feature, l logger.Interface) {
+func NewCIRAConfigRoutes(handler *gin.RouterGroup, t ciraconfigs.Feature, l logger.Interface, cfg *config.Config) {
 	r := &ciraConfigRoutes{t, l}
 
 	h := handler.Group("/ciraconfigs")
+	h.Use(ciraDisabledMiddleware(cfg.DisableCIRA))
 	{
 		h.GET("", r.get)
 		h.GET(":ciraConfigName", r.getByName)
@@ -80,15 +82,15 @@ func (r *ciraConfigRoutes) getByName(c *gin.Context) {
 }
 
 func (r *ciraConfigRoutes) insert(c *gin.Context) {
-	var config dto.CIRAConfig
-	if err := c.ShouldBindJSON(&config); err != nil {
+	var ciraConfig dto.CIRAConfig
+	if err := c.ShouldBindJSON(&ciraConfig); err != nil {
 		r.l.Error(err, "http - CIRA configs - v1 - insert")
 		ErrorResponse(c, err)
 
 		return
 	}
 
-	newCiraConfig, err := r.cira.Insert(c.Request.Context(), &config)
+	newCiraConfig, err := r.cira.Insert(c.Request.Context(), &ciraConfig)
 	if err != nil {
 		r.l.Error(err, "http - CIRA configs - v1 - insert")
 		ErrorResponse(c, err)
@@ -100,15 +102,15 @@ func (r *ciraConfigRoutes) insert(c *gin.Context) {
 }
 
 func (r *ciraConfigRoutes) update(c *gin.Context) {
-	var config dto.CIRAConfig
-	if err := c.ShouldBindJSON(&config); err != nil {
+	var ciraConfig dto.CIRAConfig
+	if err := c.ShouldBindJSON(&ciraConfig); err != nil {
 		r.l.Error(err, "http - CIRA configs - v1 - update")
 		ErrorResponse(c, err)
 
 		return
 	}
 
-	updatedConfig, err := r.cira.Update(c.Request.Context(), &config)
+	updatedConfig, err := r.cira.Update(c.Request.Context(), &ciraConfig)
 	if err != nil {
 		r.l.Error(err, "http - CIRA configs - v1 - update")
 		ErrorResponse(c, err)

--- a/internal/controller/httpapi/v1/ciraconfigs_test.go
+++ b/internal/controller/httpapi/v1/ciraconfigs_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
+	"github.com/device-management-toolkit/console/config"
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 	"github.com/device-management-toolkit/console/internal/mocks"
 	"github.com/device-management-toolkit/console/internal/usecase/ciraconfigs"
@@ -30,7 +31,7 @@ func ciraconfigsTest(t *testing.T) (*mocks.MockCIRAConfigsFeature, *gin.Engine) 
 	engine := gin.New()
 	handler := engine.Group("/api/v1/admin")
 
-	NewCIRAConfigRoutes(handler, ciraconfig, log)
+	NewCIRAConfigRoutes(handler, ciraconfig, log, &config.Config{})
 
 	return ciraconfig, engine
 }
@@ -293,6 +294,46 @@ func TestCIRAConfigRoutes(t *testing.T) {
 				jsonBytes, _ := json.Marshal(tc.response)
 				require.Equal(t, string(jsonBytes), w.Body.String())
 			}
+		})
+	}
+}
+
+func TestCIRAConfigRoutes_DisabledReturns404(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		method string
+		url    string
+	}{
+		{http.MethodGet, "/api/v1/admin/ciraconfigs"},
+		{http.MethodGet, "/api/v1/admin/ciraconfigs/example"},
+		{http.MethodPost, "/api/v1/admin/ciraconfigs"},
+		{http.MethodPatch, "/api/v1/admin/ciraconfigs"},
+		{http.MethodDelete, "/api/v1/admin/ciraconfigs/example"},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.method+" "+tc.url, func(t *testing.T) {
+			t.Parallel()
+
+			engine := gin.New()
+			handler := engine.Group("/api/v1/admin")
+
+			// Per-subtest controller/mock so parallel subtests don't share one.
+			// No expectations are set: the guard must reject before the feature is reached.
+			ciraconfig := mocks.NewMockCIRAConfigsFeature(gomock.NewController(t))
+			NewCIRAConfigRoutes(handler, ciraconfig, logger.New("error"), &config.Config{App: config.App{DisableCIRA: true}})
+
+			req, err := http.NewRequestWithContext(context.Background(), tc.method, tc.url, http.NoBody)
+			require.NoError(t, err)
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, http.StatusNotFound, w.Code)
+			require.JSONEq(t, `{"error":"CIRA is disabled on this instance"}`, w.Body.String())
 		})
 	}
 }

--- a/internal/controller/httpapi/v1/ciradisabled.go
+++ b/internal/controller/httpapi/v1/ciradisabled.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+// ciraDisabledMessage is returned when CIRA is disabled (APP_DISABLE_CIRA=true).
+const ciraDisabledMessage = "CIRA is disabled on this instance"
+
+// ciraDisabledMiddleware returns 404 for CIRA endpoints when CIRA is disabled:
+// the CIRA surface is not mounted on this instance, so the resource does not exist.
+func ciraDisabledMiddleware(disabled bool) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if disabled {
+			c.AbortWithStatusJSON(http.StatusNotFound, gin.H{errorKey: ciraDisabledMessage})
+
+			return
+		}
+
+		c.Next()
+	}
+}

--- a/internal/controller/httpapi/v1/error.go
+++ b/internal/controller/httpapi/v1/error.go
@@ -13,6 +13,7 @@ import (
 	"github.com/device-management-toolkit/console/internal/repoerrors"
 	"github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/internal/usecase/domains"
+	"github.com/device-management-toolkit/console/internal/usecase/profiles"
 	"github.com/device-management-toolkit/console/internal/usecase/sqldb"
 )
 
@@ -39,6 +40,15 @@ func ErrorResponse(c *gin.Context, err error) {
 		certPasswordErr domains.CertPasswordError
 		netErr          net.Error
 	)
+
+	if errors.Is(err, profiles.ErrCIRADisabled) {
+		c.AbortWithStatusJSON(http.StatusBadRequest, response{
+			Error:   profiles.ErrCIRADisabled.Error(),
+			Message: profiles.CIRADisabledHint,
+		})
+
+		return
+	}
 
 	switch {
 	case errors.As(err, &netErr):

--- a/internal/usecase/profiles/usecase.go
+++ b/internal/usecase/profiles/usecase.go
@@ -33,6 +33,7 @@ type UseCase struct {
 	log               logger.Interface
 	domains           domains.Feature
 	safeRequirements  security.Cryptor
+	disableCIRA       bool
 }
 
 var (
@@ -43,7 +44,10 @@ var (
 
 	ErrAMTPasswordRequired  = errors.New("amtPassword is required when generateRandomPassword is false")
 	ErrMEBXPasswordRequired = errors.New("mebxPassword is required when activation is acmactivate and generateRandomMEBxPassword is false")
+	ErrCIRADisabled         = errors.New("CIRA is disabled on this instance")
 )
+
+const CIRADisabledHint = "Re-enable CIRA on this instance, or change the connection mode on this profile."
 
 // validateProfileCreate enforces password-required invariants that only apply on
 // POST: PATCH may omit either password to leave the stored value untouched.
@@ -60,7 +64,7 @@ func validateProfileCreate(d *dto.Profile) error {
 }
 
 // New -.
-func New(r Repository, wifiConfig wificonfigs.Repository, w profilewificonfigs.Feature, i ieee8021xconfigs.Feature, log logger.Interface, d domains.Feature, c ciraconfigs.Repository, safeRequirements security.Cryptor) *UseCase {
+func New(r Repository, wifiConfig wificonfigs.Repository, w profilewificonfigs.Feature, i ieee8021xconfigs.Feature, log logger.Interface, d domains.Feature, c ciraconfigs.Repository, safeRequirements security.Cryptor, disableCIRA bool) *UseCase {
 	return &UseCase{
 		repo:              r,
 		wifiConfig:        wifiConfig,
@@ -70,6 +74,7 @@ func New(r Repository, wifiConfig wificonfigs.Repository, w profilewificonfigs.F
 		log:               log,
 		domains:           d,
 		safeRequirements:  safeRequirements,
+		disableCIRA:       disableCIRA,
 	}
 }
 
@@ -412,6 +417,10 @@ func (uc *UseCase) Export(ctx context.Context, profileName, domainName, tenantID
 		return "", "", ErrNotFound
 	}
 
+	if err := uc.validateCIRAConfig(data.CIRAConfigName); err != nil {
+		return "", "", err
+	}
+
 	err = uc.DecryptPasswords(data)
 	if err != nil {
 		return "", "", err
@@ -516,6 +525,10 @@ func (uc *UseCase) Update(ctx context.Context, d *dto.Profile, fields map[string
 		d = merged
 	}
 
+	if err := uc.validateCIRAConfig(d.CIRAConfigName); err != nil {
+		return nil, err
+	}
+
 	d1, err := uc.dtoToEntity(d)
 	if err != nil {
 		return nil, err
@@ -559,6 +572,10 @@ func (uc *UseCase) Insert(ctx context.Context, d *dto.Profile) (*dto.Profile, er
 		return nil, ErrNotValid.Wrap("Insert", "validateProfileCreate", err)
 	}
 
+	if err := uc.validateCIRAConfig(d.CIRAConfigName); err != nil {
+		return nil, err
+	}
+
 	d1, err := uc.dtoToEntity(d)
 	if err != nil {
 		return nil, err
@@ -589,6 +606,21 @@ func (uc *UseCase) validateIEEE8021xProfile(ctx context.Context, d1 *entity.Prof
 	}
 
 	return uc.checkIEEE8021xProfile(ctx, *d1.IEEE8021xProfileName, d1.TenantID, action)
+}
+
+// validateCIRAConfig rejects a profile that references a CIRA configuration when
+// CIRA is disabled on this instance (APP_DISABLE_CIRA=true). Such a profile's CIRA
+// management connection can never be established, so it must not be created,
+// updated, or exported for activation — fail loudly instead of provisioning a
+// device that silently cannot connect. This mirrors the ciradisabled HTTP guard
+// for non-UI callers (scripts, partner tooling) that bypass the CIRA endpoints.
+// The controller maps ErrCIRADisabled to a 400 with its message.
+func (uc *UseCase) validateCIRAConfig(ciraConfigName *string) error {
+	if uc.disableCIRA && ciraConfigName != nil && *ciraConfigName != "" {
+		return ErrCIRADisabled
+	}
+
+	return nil
 }
 
 func (uc *UseCase) checkIEEE8021xProfile(ctx context.Context, profileName, tenantID, action string) error {

--- a/internal/usecase/profiles/usecase_test.go
+++ b/internal/usecase/profiles/usecase_test.go
@@ -34,6 +34,12 @@ type test struct {
 func profilesTest(t *testing.T) (*profiles.UseCase, *mocks.MockProfilesRepository, *mocks.MockWiFiConfigsRepository, *mocks.MockProfileWiFiConfigsFeature) {
 	t.Helper()
 
+	return newProfilesTest(t, false)
+}
+
+func newProfilesTest(t *testing.T, disableCIRA bool) (*profiles.UseCase, *mocks.MockProfilesRepository, *mocks.MockWiFiConfigsRepository, *mocks.MockProfileWiFiConfigsFeature) {
+	t.Helper()
+
 	mockCtl := gomock.NewController(t)
 	defer mockCtl.Finish()
 
@@ -45,7 +51,7 @@ func profilesTest(t *testing.T) (*profiles.UseCase, *mocks.MockProfilesRepositor
 	cira := mocks.NewMockCIRAConfigsRepository(mockCtl)
 	security := mocks.MockCrypto{}
 	log := logger.New("error")
-	useCase := profiles.New(repo, wificonfigs, profilewificonfigs, ieeeMock, log, domains, cira, security)
+	useCase := profiles.New(repo, wificonfigs, profilewificonfigs, ieeeMock, log, domains, cira, security, disableCIRA)
 
 	return useCase, repo, wificonfigs, profilewificonfigs
 }
@@ -496,7 +502,7 @@ func TestUpdateRejectsUnknownIEEE8021xProfile(t *testing.T) {
 	ieeeMock := mocks.NewMockIEEE8021xConfigsFeature(mockCtl)
 	domainsMock := mocks.NewMockDomainsFeature(mockCtl)
 	ciraMock := mocks.NewMockCIRAConfigsRepository(mockCtl)
-	useCase := profiles.New(repo, wifiConfig, profileWifi, ieeeMock, logger.New("error"), domainsMock, ciraMock, mocks.MockCrypto{})
+	useCase := profiles.New(repo, wifiConfig, profileWifi, ieeeMock, logger.New("error"), domainsMock, ciraMock, mocks.MockCrypto{}, false)
 
 	ieeeMock.EXPECT().
 		GetByName(context.Background(), ieeeName, tenantID).
@@ -694,7 +700,7 @@ func TestHandleIEEE8021xSettings(t *testing.T) {
 
 			tc.mock(ieeeMock)
 
-			useCase := profiles.New(nil, nil, nil, ieeeMock, nil, nil, nil, nil)
+			useCase := profiles.New(nil, nil, nil, ieeeMock, nil, nil, nil, nil, false)
 
 			err := useCase.HandleIEEE8021xSettings(ctx, tc.data, configuration, tenantID)
 
@@ -758,7 +764,7 @@ func TestGetProfileData(t *testing.T) {
 
 			tc.mock(repoMock)
 
-			useCase := profiles.New(repoMock, nil, nil, nil, nil, nil, nil, nil)
+			useCase := profiles.New(repoMock, nil, nil, nil, nil, nil, nil, nil, false)
 
 			data, err := useCase.GetProfileData(ctx, tc.profileName, tenantID)
 
@@ -839,7 +845,7 @@ func TestGetDomainInformation(t *testing.T) {
 
 			tc.mock(domainsMock)
 
-			useCase := profiles.New(nil, nil, nil, nil, nil, domainsMock, nil, cryptoMock)
+			useCase := profiles.New(nil, nil, nil, nil, nil, domainsMock, nil, cryptoMock, false)
 
 			domain, err := useCase.GetDomainInformation(ctx, tc.activation, tc.domainName, tenantID)
 
@@ -884,7 +890,7 @@ func TestDecryptPasswords(t *testing.T) {
 
 			cryptoMock := &mocks.MockCrypto{}
 
-			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, cryptoMock)
+			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, cryptoMock, false)
 
 			err := useCase.DecryptPasswords(tc.data)
 
@@ -956,7 +962,7 @@ func TestBuildWirelessProfiles(t *testing.T) {
 
 			tc.mock(wifiMock)
 
-			useCase := profiles.New(nil, wifiMock, nil, ieeeMock, nil, nil, nil, cryptoMock)
+			useCase := profiles.New(nil, wifiMock, nil, ieeeMock, nil, nil, nil, cryptoMock, false)
 
 			wifiProfiles, err := useCase.BuildWirelessProfiles(ctx, wifiConfigs, tenantID)
 
@@ -1237,7 +1243,7 @@ func TestBuildConfigurationObject(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, nil)
+			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, nil, false)
 
 			result := useCase.BuildConfigurationObject(tc.profile.ProfileName, tc.profile, tc.domain, tc.wifi, tc.cira)
 
@@ -1297,7 +1303,7 @@ func TestGetWiFiConfigurations(t *testing.T) {
 
 			tc.mock(profileWiFiMock)
 
-			useCase := profiles.New(nil, nil, profileWiFiMock, nil, nil, nil, nil, nil)
+			useCase := profiles.New(nil, nil, profileWiFiMock, nil, nil, nil, nil, nil, false)
 
 			wifiConfigs, err := useCase.GetWiFiConfigurations(ctx, profileName, tenantID)
 
@@ -1345,7 +1351,7 @@ func TestSerializeAndEncryptYAML(t *testing.T) {
 
 			cryptoMock := &mocks.MockCrypto{}
 
-			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, cryptoMock)
+			useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, cryptoMock, false)
 
 			encryptedData, encryptionKey, err := useCase.SerializeAndEncryptYAML(tc.configuration)
 
@@ -1360,4 +1366,89 @@ func TestSerializeAndEncryptYAML(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestInsertRejectsCIRAProfileWhenCIRADisabled(t *testing.T) {
+	t.Parallel()
+
+	ciraName := "ciraconfig1"
+	useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, nil, true)
+
+	_, err := useCase.Insert(context.Background(), &dto.Profile{
+		ProfileName:                "p1",
+		GenerateRandomPassword:     true,
+		GenerateRandomMEBxPassword: true,
+		CIRAConfigName:             &ciraName,
+	})
+
+	require.ErrorIs(t, err, profiles.ErrCIRADisabled)
+}
+
+func TestUpdateRejectsCIRAProfileWhenCIRADisabled(t *testing.T) {
+	t.Parallel()
+
+	ciraName := "ciraconfig1"
+	useCase := profiles.New(nil, nil, nil, nil, nil, nil, nil, nil, true)
+
+	_, err := useCase.Update(context.Background(), &dto.Profile{
+		ProfileName:    "p1",
+		CIRAConfigName: &ciraName,
+	}, nil)
+
+	require.ErrorIs(t, err, profiles.ErrCIRADisabled)
+}
+
+func TestExportRejectsCIRAProfileWhenCIRADisabled(t *testing.T) {
+	t.Parallel()
+
+	ciraName := "ciraconfig1"
+	useCase, repo, _, _ := newProfilesTest(t, true)
+
+	repo.EXPECT().
+		GetByName(context.Background(), "p1", "tenant-id-456").
+		Return(&entity.Profile{ProfileName: "p1", TenantID: "tenant-id-456", CIRAConfigName: &ciraName}, nil)
+
+	_, _, err := useCase.Export(context.Background(), "p1", "", "tenant-id-456")
+
+	require.ErrorIs(t, err, profiles.ErrCIRADisabled)
+}
+
+// A profile that does not use CIRA must still work when CIRA is disabled.
+func TestUpdateAllowsNonCIRAProfileWhenCIRADisabled(t *testing.T) {
+	t.Parallel()
+
+	profile := &entity.Profile{
+		ProfileName:  "example-profile",
+		TenantID:     "tenant-id-456",
+		Version:      "1.0.0",
+		AMTPassword:  "encrypted",
+		MEBXPassword: "encrypted",
+	}
+
+	profileDTO := &dto.Profile{
+		ProfileName: "example-profile",
+		TenantID:    "tenant-id-456",
+		Version:     "1.0.0",
+		Tags:        []string{""},
+		WiFiConfigs: []dto.ProfileWiFiConfigs{
+			{
+				ProfileName:         "example-profile",
+				WirelessProfileName: "wireless-profile-1",
+			},
+		},
+	}
+
+	useCase, repo, wifiFeat, pwfFeat := newProfilesTest(t, true)
+
+	repo.EXPECT().Update(context.Background(), profile).Return(true, nil)
+	pwfFeat.EXPECT().DeleteByProfileName(context.Background(), profile.ProfileName, profile.TenantID).Return(nil)
+	repo.EXPECT().GetByName(context.Background(), profile.ProfileName, profile.TenantID).Return(profile, nil)
+	wifiFeat.EXPECT().
+		CheckProfileExists(context.Background(), profileDTO.WiFiConfigs[0].WirelessProfileName, profileDTO.TenantID).
+		Return(true, nil)
+
+	result, err := useCase.Update(context.Background(), profileDTO, nil)
+
+	require.NoError(t, err)
+	require.Equal(t, profileDTO, result)
 }

--- a/internal/usecase/usecase.go
+++ b/internal/usecase/usecase.go
@@ -94,7 +94,7 @@ func NewUseCases(repos *Repos, log logger.Interface, certStore security.Storager
 		Domains:            domains1,
 		Devices:            devices.New(repos.Devices, wsman1, devices.NewRedirector(safeRequirements), log, safeRequirements),
 		AMTExplorer:        amtexplorer.New(repos.Devices, wsman2, log, safeRequirements),
-		Profiles:           profiles.New(repos.Profiles, repos.WirelessConfigs, pwc, ieee, log, domains1, repos.CIRAConfigs, safeRequirements),
+		Profiles:           profiles.New(repos.Profiles, repos.WirelessConfigs, pwc, ieee, log, domains1, repos.CIRAConfigs, safeRequirements, config.ConsoleConfig.DisableCIRA),
 		IEEE8021xProfiles:  ieee,
 		CIRAConfigs:        ciraconfigs.New(repos.CIRAConfigs, log, safeRequirements),
 		WirelessProfiles:   wificonfig,

--- a/internal/usecase/usecase_test.go
+++ b/internal/usecase/usecase_test.go
@@ -71,6 +71,7 @@ func TestUsecases(t *testing.T) {
 					domains.New(sqldb.NewDomainRepo(&db.SQL{}, mocks.NewMockLogger(nil)), mocks.NewMockLogger(nil), safeRequirements, nil),
 					sqldb.NewCIRARepo(&db.SQL{}, mocks.NewMockLogger(nil)),
 					safeRequirements,
+					false,
 				),
 				IEEE8021xProfiles:  ieee8021xconfigs.New(sqldb.NewIEEE8021xRepo(&db.SQL{}, mocks.NewMockLogger(nil)), mocks.NewMockLogger(nil)),
 				CIRAConfigs:        ciraconfigs.New(sqldb.NewCIRARepo(&db.SQL{}, mocks.NewMockLogger(nil)), mocks.NewMockLogger(nil), safeRequirements),


### PR DESCRIPTION
When APP_DISABLE_CIRA=true, CIRA is enforced off across the API:

- the CIRA config and certificate endpoints return 404 with
  "CIRA is disabled on this instance" (the surface is not mounted on
  this instance); and
- a profile that references a CIRA configuration is rejected on create,
  update, and export with 400, so a device is never provisioned with a
  CIRA connection that can never be established.
  
  Issue it resolves :  https://github.com/device-management-toolkit/sample-web-ui/issues/3200