### PR TITLE
perf(api): optimize redfish action device lookup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,14 +7,14 @@
 ARG BUILD_TAGS=""
 
 # Step 1: Modules caching
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS modules
+FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS modules
 COPY go.mod go.sum /modules/
 WORKDIR /modules
 RUN apk add --no-cache git
 RUN go mod download
 
 # Step 2: Builder
-FROM golang:1.26.3-alpine@sha256:91eda9776261207ea25fd06b5b7fed8d397dd2c0a283e77f2ab6e91bfa71079d AS builder
+FROM golang:1.26-alpine@sha256:f23e8b227fb4493eabe03bede4d5a32d04092da71962f1fb79b5f7d1e6c2a17f AS builder
 # Build tags control dependencies:
 # - Default (no tags): Full build with UI
 # - noui: Excludes web UI assets

--- a/redfish/component.go
+++ b/redfish/component.go
@@ -71,12 +71,16 @@ func Initialize(_ *gin.Engine, log logger.Interface, _ *db.SQL, usecases *dmtuse
 	// Check if we should use mock repository (for testing)
 	useMock := os.Getenv("REDFISH_USE_MOCK") == "true"
 
-	var repo redfishusecase.ComputerSystemRepository
+	var (
+		repo       redfishusecase.ComputerSystemRepository
+		deviceRepo redfishusecase.DeviceLookupRepository
+	)
 
 	if useMock {
 		log.Info("Using mock WSMAN repository for Redfish API")
 
 		repo = mocks.NewMockComputerSystemRepo()
+		deviceRepo = redfishusecase.DeviceLookupFromComputerSystemRepo{Repo: repo}
 	} else {
 		// Create Redfish-specific repository and use case using DMT's device management
 		devicesUC, ok := usecases.Devices.(*devices.UseCase)
@@ -87,9 +91,10 @@ func Initialize(_ *gin.Engine, log logger.Interface, _ *db.SQL, usecases *dmtuse
 		}
 
 		repo = redfishusecase.NewWsmanComputerSystemRepo(devicesUC, log)
+		deviceRepo = devicesUC
 	}
 
-	computerSystemUC := &redfishusecase.ComputerSystemUseCase{Repo: repo}
+	computerSystemUC := &redfishusecase.ComputerSystemUseCase{Repo: repo, DeviceRepo: deviceRepo}
 
 	// Create session repository and use case
 	const sessionCleanupInterval = 5 * time.Minute

--- a/redfish/internal/controller/http/v1/handler/systems_actions.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions.go
@@ -59,6 +59,17 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsComputerSyste
 
 	log.Infof("Received reset request for ComputerSystem %s with ResetType %s", computerSystemID, *req.ResetType)
 
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
 	if err := s.ComputerSystemUC.SetPowerState(c.Request.Context(), computerSystemID, *req.ResetType); err != nil {
 		switch {
 		case errors.Is(err, usecase.ErrSystemNotFound):
@@ -125,6 +136,17 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 
 	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
 		MalformedJSONError(c)
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
 
 		return
 	}
@@ -215,6 +237,17 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 		return
 	}
 
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
 	if err := s.ComputerSystemUC.RequestKVMConsent(c.Request.Context(), computerSystemID); err != nil {
 		var consentErr *usecase.ConsentFailedError
 
@@ -278,6 +311,17 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 
 	if !sixDigitConsentCodeRe.MatchString(consentCode) {
 		BadRequestError(c, "Invalid ConsentCode: must be a six-digit numeric value")
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
 
 		return
 	}

--- a/redfish/internal/controller/http/v1/handler/systems_actions_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions_test.go
@@ -16,12 +16,40 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/device-management-toolkit/console/config"
+	devicev1 "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	devusecase "github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
 	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
 	"github.com/device-management-toolkit/console/redfish/internal/usecase"
 )
 
 var configTestMu sync.Mutex
+
+type testActionDeviceLookupRepo struct {
+	repo *TestSystemsComputerSystemRepository
+	err  error
+}
+
+func (r testActionDeviceLookupRepo) GetByID(_ context.Context, guid, _ string, _ bool) (*devicev1.Device, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if _, exists := r.repo.systems[guid]; !exists {
+		return nil, devusecase.ErrNotFound
+	}
+
+	return &devicev1.Device{GUID: guid}, nil
+}
+
+func setupSystemActionsTestServerWithLookup(repo *TestSystemsComputerSystemRepository, lookup testActionDeviceLookupRepo) *RedfishServer {
+	uc := &usecase.ComputerSystemUseCase{
+		Repo:       repo,
+		DeviceRepo: lookup,
+	}
+
+	return &RedfishServer{ComputerSystemUC: uc}
+}
 
 // Test constants for system actions
 const (
@@ -39,7 +67,8 @@ const (
 // setupSystemActionsTestServer creates a test server with a mock repository
 func setupSystemActionsTestServer(repo *TestSystemsComputerSystemRepository) *RedfishServer {
 	uc := &usecase.ComputerSystemUseCase{
-		Repo: repo,
+		Repo:       repo,
+		DeviceRepo: testActionDeviceLookupRepo{repo: repo},
 	}
 
 	return &RedfishServer{
@@ -881,6 +910,63 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancel
 	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, "../invalid")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsComputerSystemReset_DeviceLookupInternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
+	server := setupSystemActionsTestServerWithLookup(repo, testActionDeviceLookupRepo{repo: repo, err: errors.New("lookup failure")})
+	router := setupSystemActionsTestRouter(server)
+
+	body := createResetRequest(generated.ResourceResetTypeOn)
+	w := executeResetRequest(router, resetActionEndpoint, body)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestKVMConsent_DeviceLookupInternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
+	server := setupSystemActionsTestServerWithLookup(repo, testActionDeviceLookupRepo{repo: repo, err: errors.New("lookup failure")})
+	router := setupSystemActionsTestRouter(server)
+
+	w := executeResetRequest(router, requestKVMConsentEndpoint, createEmptyActionRequest())
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitKVMConsentCode_DeviceLookupInternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
+	server := setupSystemActionsTestServerWithLookup(repo, testActionDeviceLookupRepo{repo: repo, err: errors.New("lookup failure")})
+	router := setupSystemActionsTestRouter(server)
+
+	w := executeResetRequest(router, submitKVMConsentEndpoint, createSubmitKVMConsentCodeRequest("123456"))
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelKVMConsent_DeviceLookupInternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
+	server := setupSystemActionsTestServerWithLookup(repo, testActionDeviceLookupRepo{repo: repo, err: errors.New("lookup failure")})
+	router := setupSystemActionsTestRouter(server)
+
+	w := executeResetRequest(router, cancelKVMConsentEndpoint, createEmptyActionRequest())
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
 func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_Stub(t *testing.T) {

--- a/redfish/internal/usecase/computer_system.go
+++ b/redfish/internal/usecase/computer_system.go
@@ -10,6 +10,8 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/device-management-toolkit/console/config"
+	devicev1 "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	devusecase "github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
 	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
 )
@@ -38,6 +40,9 @@ var (
 
 	// ErrConsoleConfigNotInitialized is returned when console config is not initialized.
 	ErrConsoleConfigNotInitialized = errors.New("console config is not initialized")
+
+	// ErrDeviceLookupNotConfigured is returned when device lookup dependency is missing.
+	ErrDeviceLookupNotConfigured = errors.New("device lookup repository is not configured")
 )
 
 // OData and schema constants for ComputerSystem.
@@ -80,7 +85,37 @@ const (
 
 // ComputerSystemUseCase provides business logic for ComputerSystem entities.
 type ComputerSystemUseCase struct {
+	Repo       ComputerSystemRepository
+	DeviceRepo DeviceLookupRepository
+}
+
+// DeviceLookupRepository defines the minimal dependency needed to validate
+// device existence for token generation without triggering Redfish WSMAN hydration.
+type DeviceLookupRepository interface {
+	GetByID(ctx context.Context, guid, tenantID string, includeSecrets bool) (*devicev1.Device, error)
+}
+
+// DeviceLookupFromComputerSystemRepo adapts a ComputerSystemRepository for
+// mock/test flows that do not have direct access to the devices use case.
+type DeviceLookupFromComputerSystemRepo struct {
 	Repo ComputerSystemRepository
+}
+
+// GetByID validates existence via the wrapped ComputerSystemRepository.
+func (a DeviceLookupFromComputerSystemRepo) GetByID(ctx context.Context, guid, _ string, _ bool) (*devicev1.Device, error) {
+	if a.Repo == nil {
+		return nil, ErrDeviceLookupNotConfigured
+	}
+
+	if _, err := a.Repo.GetByID(ctx, guid); err != nil {
+		if errors.Is(err, ErrSystemNotFound) {
+			return nil, devusecase.ErrNotFound
+		}
+
+		return nil, err
+	}
+
+	return &devicev1.Device{GUID: guid}, nil
 }
 
 // GetAll retrieves all ComputerSystem IDs from the repository.
@@ -196,6 +231,24 @@ func (uc *ComputerSystemUseCase) GetComputerSystem(ctx context.Context, systemID
 	}
 
 	return &result, nil
+}
+
+// EnsureSystemExists validates that the requested system exists via the configured
+// device lookup repository.
+func (uc *ComputerSystemUseCase) EnsureSystemExists(ctx context.Context, systemID string) error {
+	if uc.DeviceRepo == nil {
+		return ErrDeviceLookupNotConfigured
+	}
+
+	if _, err := uc.DeviceRepo.GetByID(ctx, systemID, "", false); err != nil {
+		if errors.Is(err, devusecase.ErrNotFound) || errors.Is(err, ErrSystemNotFound) {
+			return ErrSystemNotFound
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // SetPowerState validates and sets the power state for a ComputerSystem.
@@ -522,7 +575,7 @@ func (uc *ComputerSystemUseCase) CancelKVMConsent(ctx context.Context, systemID 
 
 // GenerateRedirectionToken validates that the target system exists and returns a short-lived redirection token.
 func (uc *ComputerSystemUseCase) GenerateRedirectionToken(ctx context.Context, systemID string) (*generated.ComputerSystemOemIntelAmtGenerateRedirectionTokenResponse, error) {
-	if _, err := uc.Repo.GetByID(ctx, systemID); err != nil {
+	if err := uc.EnsureSystemExists(ctx, systemID); err != nil {
 		return nil, err
 	}
 

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -4,7 +4,11 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
+	"github.com/device-management-toolkit/console/config"
+	devicev1 "github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	devusecase "github.com/device-management-toolkit/console/internal/usecase/devices"
 	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
 	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
 )
@@ -15,6 +19,7 @@ type graphicalConsoleTestRepo struct {
 	kvmErr  error
 	solErr  error
 	ccErr   error
+	getErr  error
 }
 
 func (r *graphicalConsoleTestRepo) GetAll(_ context.Context) ([]string, error) {
@@ -22,6 +27,10 @@ func (r *graphicalConsoleTestRepo) GetAll(_ context.Context) ([]string, error) {
 }
 
 func (r *graphicalConsoleTestRepo) GetByID(_ context.Context, _ string) (*redfishv1.ComputerSystem, error) {
+	if r.getErr != nil {
+		return nil, r.getErr
+	}
+
 	if r.system == nil {
 		return nil, ErrSystemNotFound
 	}
@@ -802,5 +811,191 @@ func assertActionTarget(t *testing.T, actionName string, got *string, want strin
 
 	if got == nil || *got != want {
 		t.Fatalf("expected %s action target %q, got %#v", actionName, want, got)
+	}
+}
+
+type testDeviceLookupRepo struct {
+	device *devicev1.Device
+	err    error
+}
+
+func (r testDeviceLookupRepo) GetByID(_ context.Context, _, _ string, _ bool) (*devicev1.Device, error) {
+	if r.err != nil {
+		return nil, r.err
+	}
+
+	if r.device != nil {
+		return r.device, nil
+	}
+
+	return &devicev1.Device{GUID: "system-1"}, nil
+}
+
+func TestEnsureSystemExists(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		deviceRepo DeviceLookupRepository
+		wantErr    error
+	}{
+		{name: "missing device repo", wantErr: ErrDeviceLookupNotConfigured},
+		{name: "not found from devices repo", deviceRepo: testDeviceLookupRepo{err: devusecase.ErrNotFound}, wantErr: ErrSystemNotFound},
+		{name: "not found from usecase error", deviceRepo: testDeviceLookupRepo{err: ErrSystemNotFound}, wantErr: ErrSystemNotFound},
+		{name: "other lookup error", deviceRepo: testDeviceLookupRepo{err: errors.New("lookup failed")}, wantErr: errors.New("lookup failed")},
+		{name: "success", deviceRepo: testDeviceLookupRepo{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc := &ComputerSystemUseCase{DeviceRepo: tt.deviceRepo}
+			err := uc.EnsureSystemExists(context.Background(), "system-1")
+
+			if tt.wantErr == nil {
+				if err != nil {
+					t.Fatalf("EnsureSystemExists() unexpected error: %v", err)
+				}
+
+				return
+			}
+
+			if err == nil || err.Error() != tt.wantErr.Error() {
+				t.Fatalf("EnsureSystemExists() error = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeviceLookupFromComputerSystemRepoGetByID(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		repo    ComputerSystemRepository
+		wantErr error
+		wantMsg string
+	}{
+		{name: "nil repo", repo: nil, wantErr: ErrDeviceLookupNotConfigured},
+		{name: "system not found", repo: &graphicalConsoleTestRepo{system: nil}, wantErr: devusecase.ErrNotFound},
+		{name: "repo failure", repo: &graphicalConsoleTestRepo{getErr: errors.New("repo failed")}, wantMsg: "repo failed"},
+		{name: "success", repo: &graphicalConsoleTestRepo{system: &redfishv1.ComputerSystem{ID: "system-1"}}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			lookup := DeviceLookupFromComputerSystemRepo{Repo: tt.repo}
+			device, err := lookup.GetByID(context.Background(), "system-1", "", false)
+			assertDeviceLookupResult(t, device, err, tt.wantErr, tt.wantMsg)
+		})
+	}
+}
+
+func assertDeviceLookupResult(t *testing.T, device *devicev1.Device, err, wantErr error, wantMsg string) {
+	t.Helper()
+
+	if wantErr == nil && wantMsg == "" {
+		if err != nil {
+			t.Fatalf("GetByID() unexpected error: %v", err)
+		}
+
+		if device == nil || device.GUID != "system-1" {
+			t.Fatalf("GetByID() expected device GUID system-1, got %#v", device)
+		}
+
+		return
+	}
+
+	if wantErr != nil {
+		if !errors.Is(err, wantErr) {
+			t.Fatalf("GetByID() error = %v, want %v", err, wantErr)
+		}
+
+		return
+	}
+
+	if err == nil || err.Error() != wantMsg {
+		t.Fatalf("GetByID() error = %v, want %q", err, wantMsg)
+	}
+}
+
+func TestGenerateRedirectionToken_UsesDeviceRepo(t *testing.T) {
+	t.Parallel()
+
+	original := config.ConsoleConfig
+	config.ConsoleConfig = &config.Config{}
+	config.ConsoleConfig.JWTKey = "test-key"
+	config.ConsoleConfig.RedirectionJWTExpiration = 5 * time.Minute
+
+	t.Cleanup(func() {
+		config.ConsoleConfig = original
+	})
+
+	tests := []struct {
+		name       string
+		deviceRepo DeviceLookupRepository
+		wantErr    error
+	}{
+		{name: "missing device repo", wantErr: ErrDeviceLookupNotConfigured},
+		{name: "device not found", deviceRepo: testDeviceLookupRepo{err: devusecase.ErrNotFound}, wantErr: ErrSystemNotFound},
+		{name: "lookup failure", deviceRepo: testDeviceLookupRepo{err: errors.New("db unavailable")}, wantErr: errors.New("db unavailable")},
+		{name: "success", deviceRepo: testDeviceLookupRepo{}},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc := &ComputerSystemUseCase{DeviceRepo: tt.deviceRepo}
+			resp, err := uc.GenerateRedirectionToken(context.Background(), "system-1")
+			assertGenerateTokenResult(t, resp, err, tt.wantErr)
+		})
+	}
+}
+
+func assertGenerateTokenResult(t *testing.T, resp *generated.ComputerSystemOemIntelAmtGenerateRedirectionTokenResponse, err, wantErr error) {
+	t.Helper()
+
+	if wantErr == nil {
+		if err != nil {
+			t.Fatalf("GenerateRedirectionToken() unexpected error: %v", err)
+		}
+
+		if resp == nil || resp.RedirectionToken == nil || *resp.RedirectionToken == "" {
+			t.Fatalf("GenerateRedirectionToken() expected non-empty token, got %#v", resp)
+		}
+
+		return
+	}
+
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("GenerateRedirectionToken() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestGenerateRedirectionToken_ConfigNotInitialized(t *testing.T) {
+	t.Parallel()
+
+	original := config.ConsoleConfig
+	config.ConsoleConfig = nil
+
+	t.Cleanup(func() {
+		config.ConsoleConfig = original
+	})
+
+	uc := &ComputerSystemUseCase{DeviceRepo: testDeviceLookupRepo{}}
+
+	_, err := uc.GenerateRedirectionToken(context.Background(), "system-1")
+	if !errors.Is(err, ErrConsoleConfigNotInitialized) {
+		t.Fatalf("GenerateRedirectionToken() error = %v, want %v", err, ErrConsoleConfigNotInitialized)
 	}
 }


### PR DESCRIPTION
The PR introduces an optimization w.r.t device lookup where instead of query for the validate device-id (UUID) through WS-MAN API's we query with the local device repo.