### PR TITLE
chore: sync Redfish artifacts from redfish-tools manual-26941281551

### DIFF
--- a/redfish/openapi/redfish-openapi.yaml
+++ b/redfish/openapi/redfish-openapi.yaml
@@ -3243,6 +3243,13 @@ components:
             that cannot be conveyed with other properties defined for the Placement
             object.
           x-versionAdded: v1_7_0
+        FacilityName:
+          description: The name of the facility.
+          nullable: true
+          readOnly: false
+          type: string
+          x-longDescription: This property shall contain the name of the facility.
+          x-versionAdded: v1_23_0
         Rack:
           description: The name of a rack location within a row.
           nullable: true
@@ -3257,8 +3264,9 @@ components:
           nullable: true
           readOnly: false
           type: integer
-          x-longDescription: The vertical location of the item in the rack.  Rack
-            offset units shall be measured from bottom to top, starting with 0.
+          x-longDescription: The vertical location of the item in the rack, at the
+            lowest point of the unit.  Rack offset units shall be measured from bottom
+            to top, starting with 0.
           x-versionAdded: v1_3_0
         RackOffsetUnits:
           description: The type of rack units in use.
@@ -3270,6 +3278,14 @@ components:
           x-longDescription: This property shall contain a RackUnit enumeration literal
             that indicates the type of rack units in use.
           x-versionAdded: v1_3_0
+        Room:
+          description: The name or number of the room.
+          nullable: true
+          readOnly: false
+          type: string
+          x-longDescription: This property shall contain the name or number of the
+            room.
+          x-versionAdded: v1_23_0
         Row:
           description: The name of the row.
           nullable: true


### PR DESCRIPTION
Automated sync of generated Redfish artifacts from redfish-tools.

Source:
- manual-26941281551
- https://github.com/device-management-toolkit/redfish-tools/actions/runs/26941281551

Generated and synced files:
- redfish/openapi/redfish-openapi.yaml
- redfish/internal/controller/http/v1/generated/spec.gen.go
- redfish/internal/controller/http/v1/generated/types.gen.go
- redfish/internal/controller/http/v1/generated/server.gen.go
- redfish/internal/controller/http/v1/handler/metadata.xml