### PR TITLE
feat(api): add wired network settings get and patch endpoints

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -818,6 +818,101 @@
 					"response": []
 				},
 				{
+					"name": "Get Wired Network Settings",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {\r",
+									"    pm.response.to.have.status(404);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Device should not be found\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.error).to.eq(\"Error not found\")\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/amt/networkSettings/wired/{{deviceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"amt",
+								"networkSettings",
+								"wired",
+								"{{deviceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Wired Network Settings",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {\r",
+									"    pm.response.to.have.status(404);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Device should not be found\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.error).to.eq(\"Error not found\")\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "PATCH",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"dhcpEnabled\": false,\r\n    \"ipAddress\": \"192.168.1.50\",\r\n    \"subnetMask\": \"255.255.255.0\",\r\n    \"defaultGateway\": \"192.168.1.1\",\r\n    \"primaryDNS\": \"192.168.1.1\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/amt/networkSettings/wired/{{deviceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"amt",
+								"networkSettings",
+								"wired",
+								"{{deviceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get Wireless State",
 					"event": [
 						{

--- a/internal/controller/httpapi/v1/devicemanagement.go
+++ b/internal/controller/httpapi/v1/devicemanagement.go
@@ -50,6 +50,8 @@ func NewAmtRoutes(handler *gin.RouterGroup, d devices.Feature, amt amtexplorer.F
 		h.POST("userConsentCode/:guid", r.sendConsentCode)
 
 		h.GET("networkSettings/:guid", r.getNetworkSettings)
+		h.GET("networkSettings/wired/:guid", r.getWiredNetworkSettings)
+		h.PATCH("networkSettings/wired/:guid", r.patchWiredNetworkSettings)
 		h.GET("networkSettings/wireless/state/:guid", r.getWirelessState)
 		h.POST("networkSettings/wireless/state/:guid", r.requestWirelessStateChange)
 		h.GET("networkSettings/wireless/profile/:guid", r.getWirelessProfiles)

--- a/internal/controller/httpapi/v1/devicemanagement_test.go
+++ b/internal/controller/httpapi/v1/devicemanagement_test.go
@@ -301,6 +301,73 @@ func TestDeviceManagement(t *testing.T) {
 			response:     dto.NetworkSettings{},
 		},
 		{
+			name:   "getNetworkSettings - failed retrieval",
+			url:    "/api/v1/amt/networkSettings/valid-guid",
+			method: http.MethodGet,
+			mock: func(m *mocks.MockDeviceManagementFeature) {
+				m.EXPECT().GetNetworkSettings(context.Background(), "valid-guid").
+					Return(dto.NetworkSettings{}, ErrGeneral)
+			},
+			expectedCode: http.StatusInternalServerError,
+			response:     nil,
+		},
+		{
+			name:   "getWiredNetworkSettings - successful retrieval",
+			url:    "/api/v1/amt/networkSettings/wired/valid-guid",
+			method: http.MethodGet,
+			mock: func(m *mocks.MockDeviceManagementFeature) {
+				m.EXPECT().GetWiredNetworkSettings(context.Background(), "valid-guid").
+					Return(dto.WiredNetworkInfo{}, nil)
+			},
+			expectedCode: http.StatusOK,
+			response:     dto.WiredNetworkInfo{},
+		},
+		{
+			name:   "getWiredNetworkSettings - failed retrieval",
+			url:    "/api/v1/amt/networkSettings/wired/valid-guid",
+			method: http.MethodGet,
+			mock: func(m *mocks.MockDeviceManagementFeature) {
+				m.EXPECT().GetWiredNetworkSettings(context.Background(), "valid-guid").
+					Return(dto.WiredNetworkInfo{}, ErrGeneral)
+			},
+			expectedCode: http.StatusInternalServerError,
+			response:     nil,
+		},
+		{
+			name:        "patchWiredNetworkSettings - successful update",
+			url:         "/api/v1/amt/networkSettings/wired/valid-guid",
+			method:      http.MethodPatch,
+			requestBody: map[string]interface{}{"dhcpEnabled": true},
+			mock: func(m *mocks.MockDeviceManagementFeature) {
+				m.EXPECT().PatchWiredNetworkSettings(context.Background(), "valid-guid", gomock.Any()).
+					Return(nil)
+			},
+			expectedCode: http.StatusNoContent,
+			response:     nil,
+		},
+		{
+			name:        "patchWiredNetworkSettings - use case error",
+			url:         "/api/v1/amt/networkSettings/wired/valid-guid",
+			method:      http.MethodPatch,
+			requestBody: map[string]interface{}{"dhcpEnabled": true},
+			mock: func(m *mocks.MockDeviceManagementFeature) {
+				validationErr := dto.NotValidError{Console: consoleerrors.CreateConsoleError("PatchWiredNetworkSettings")}
+				m.EXPECT().PatchWiredNetworkSettings(context.Background(), "valid-guid", gomock.Any()).
+					Return(validationErr)
+			},
+			expectedCode: http.StatusBadRequest,
+			response:     nil,
+		},
+		{
+			name:         "patchWiredNetworkSettings - binding error",
+			url:          "/api/v1/amt/networkSettings/wired/valid-guid",
+			method:       http.MethodPatch,
+			requestBody:  map[string]interface{}{"dhcpEnabled": "not-a-bool"},
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			expectedCode: http.StatusInternalServerError,
+			response:     nil,
+		},
+		{
 			name:   "getCertificates - successful retrieval",
 			url:    "/api/v1/amt/certificates/valid-guid",
 			method: http.MethodGet,

--- a/internal/controller/httpapi/v1/network.go
+++ b/internal/controller/httpapi/v1/network.go
@@ -4,6 +4,8 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 )
 
 func (r *deviceManagementRoutes) getNetworkSettings(c *gin.Context) {
@@ -18,4 +20,40 @@ func (r *deviceManagementRoutes) getNetworkSettings(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, network)
+}
+
+// getWiredNetworkSettings returns the wired network settings for a device.
+func (r *deviceManagementRoutes) getWiredNetworkSettings(c *gin.Context) {
+	guid := c.Param("guid")
+
+	wired, err := r.d.GetWiredNetworkSettings(c.Request.Context(), guid)
+	if err != nil {
+		r.l.Error(err, "http - v1 - getWiredNetworkSettings")
+		ErrorResponse(c, err)
+
+		return
+	}
+
+	c.JSON(http.StatusOK, wired)
+}
+
+// patchWiredNetworkSettings updates the wired IPv4 configuration for a device.
+func (r *deviceManagementRoutes) patchWiredNetworkSettings(c *gin.Context) {
+	guid := c.Param("guid")
+
+	var req dto.WiredNetworkConfigRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		ErrorResponse(c, err)
+
+		return
+	}
+
+	if err := r.d.PatchWiredNetworkSettings(c.Request.Context(), guid, req); err != nil {
+		r.l.Error(err, "http - v1 - patchWiredNetworkSettings")
+		ErrorResponse(c, err)
+
+		return
+	}
+
+	c.Status(http.StatusNoContent)
 }

--- a/internal/controller/openapi/devicemanagement.go
+++ b/internal/controller/openapi/devicemanagement.go
@@ -13,7 +13,8 @@ import (
 func (f *FuegoAdapter) RegisterDeviceManagementRoutes() {
 	f.registerKVMAndCertificateRoutes()
 	f.registerExplorerRoutes()
-	f.registerNetworkAndFeatureRoutes()
+	f.registerNetworkRoutes()
+	f.registerFeatureRoutes()
 	f.registerUserConsentRoutes()
 	f.registerPowerRoutes()
 	f.registerLogsAndAlarmRoutes()
@@ -85,7 +86,7 @@ func (f *FuegoAdapter) registerExplorerRoutes() {
 	)
 }
 
-func (f *FuegoAdapter) registerNetworkAndFeatureRoutes() {
+func (f *FuegoAdapter) registerNetworkRoutes() {
 	// TLS settings
 	fuego.Get(f.server, "/api/v1/amt/tls/{guid}", f.getTLSSettingData,
 		fuego.OptionTags("Device Management"),
@@ -101,6 +102,23 @@ func (f *FuegoAdapter) registerNetworkAndFeatureRoutes() {
 		fuego.OptionSummary("Get Network Settings"),
 		fuego.OptionDescription("Retrieve network settings for a device"),
 		fuego.OptionPath("guid", "Device GUID"),
+		protectedRouteOptions(),
+	)
+
+	fuego.Get(f.server, "/api/v1/amt/networkSettings/wired/{guid}", f.getWiredNetworkSettings,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Get Wired Network Settings"),
+		fuego.OptionDescription("Retrieve the wired network settings for a device"),
+		fuego.OptionPath("guid", "Device GUID"),
+		protectedRouteOptions(),
+	)
+
+	fuego.Patch(f.server, "/api/v1/amt/networkSettings/wired/{guid}", f.patchWiredNetworkSettings,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Update Wired Network Settings"),
+		fuego.OptionDescription("Update the wired IPv4 configuration (DHCP or static IP) for a device"),
+		fuego.OptionPath("guid", "Device GUID"),
+		fuego.OptionDefaultStatusCode(http.StatusNoContent),
 		protectedRouteOptions(),
 	)
 
@@ -163,7 +181,9 @@ func (f *FuegoAdapter) registerNetworkAndFeatureRoutes() {
 		fuego.OptionPath("guid", "Device GUID"),
 		protectedRouteOptions(),
 	)
+}
 
+func (f *FuegoAdapter) registerFeatureRoutes() {
 	// Features
 	fuego.Get(f.server, "/api/v1/amt/features/{guid}", f.getFeatures,
 		fuego.OptionTags("Device Management"),
@@ -436,6 +456,19 @@ func (f *FuegoAdapter) getTLSSettingData(_ fuego.ContextNoBody) ([]dto.SettingDa
 
 func (f *FuegoAdapter) getNetworkSettings(_ fuego.ContextNoBody) (dto.NetworkSettings, error) {
 	return dto.NetworkSettings{}, nil
+}
+
+func (f *FuegoAdapter) getWiredNetworkSettings(_ fuego.ContextNoBody) (dto.WiredNetworkInfo, error) {
+	return dto.WiredNetworkInfo{}, nil
+}
+
+func (f *FuegoAdapter) patchWiredNetworkSettings(c fuego.ContextWithBody[dto.WiredNetworkConfigRequest]) (NoContentResponse, error) {
+	_, err := c.Body()
+	if err != nil {
+		return NoContentResponse{}, err
+	}
+
+	return NoContentResponse{}, nil
 }
 
 func (f *FuegoAdapter) getWirelessState(_ fuego.ContextNoBody) (dto.WirelessStateResponse, error) {

--- a/internal/controller/ws/v1/interface.go
+++ b/internal/controller/ws/v1/interface.go
@@ -60,6 +60,8 @@ type Feature interface {
 	GetEventLog(ctx context.Context, startIndex, maxReadRecords int, guid string) (dto.EventLogs, error)
 	Redirect(ctx context.Context, conn *websocket.Conn, guid, mode string) error
 	GetNetworkSettings(c context.Context, guid string) (dto.NetworkSettings, error)
+	GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error)
+	PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error
 	RequestWirelessStateChange(c context.Context, guid string, requestedState wifi.RequestedState) (wifi.RequestedState, error)
 	GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error)
 	GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error)

--- a/internal/entity/dto/v1/network.go
+++ b/internal/entity/dto/v1/network.go
@@ -35,6 +35,39 @@ type WiredNetworkInfo struct {
 	NetworkInfo
 	IEEE8021x IEEE8021x `json:"ieee8021x"`
 }
+
+// WiredNetworkConfigRequest represents a request to update a device's wired
+// (Intel® AMT Ethernet Port Settings 0) IPv4 configuration. Field-level format
+// validation is enforced by the binding tags; the DHCP vs static-IP combination
+// rules are enforced in the use case.
+type WiredNetworkConfigRequest struct {
+	DHCPEnabled    *bool                 `json:"dhcpEnabled" binding:"required"`          // Required: true selects DHCP mode (IP sync is forced on and explicit IP fields are ignored); false selects static IP mode, either manual or host-synced depending on ipSyncEnabled.
+	IPSyncEnabled  *bool                 `json:"ipSyncEnabled"`                           // Optional, static mode only: true synchronizes the IP settings with the host OS and explicit static IP fields must not be supplied; false (or unset, defaulting to the device's current value) selects manual static IP. Ignored when DHCP is enabled.
+	IPAddress      string                `json:"ipAddress" binding:"omitempty,ipv4"`      // Required for static IP mode (DHCP disabled, IP sync disabled).
+	SubnetMask     string                `json:"subnetMask" binding:"omitempty,ipv4"`     // Required for static IP mode.
+	DefaultGateway string                `json:"defaultGateway" binding:"omitempty,ipv4"` // Required for static IP mode.
+	PrimaryDNS     string                `json:"primaryDNS" binding:"omitempty,ipv4"`     // Required for static IP mode.
+	SecondaryDNS   string                `json:"secondaryDNS" binding:"omitempty,ipv4"`   // Optional for static IP mode.
+	IEEE8021x      *WiredIEEE8021xConfig `json:"ieee8021x,omitempty"`                     // Optional: wired 802.1X authentication. Not yet supported; supplying this object returns HTTP 501.
+}
+
+// WiredIEEE8021xConfig represents a request to configure wired 802.1X (port-based
+// network access control) authentication on the AMT Ethernet port.
+//
+// NOTE: This is a forward-looking API contract. Wired 802.1X configuration is not
+// yet implemented; supplying this object causes PatchWiredNetworkSettings to return
+// a "not supported" error (HTTP 501). The field shape is defined now so that the
+// future implementation is purely additive and does not break existing clients.
+type WiredIEEE8021xConfig struct {
+	ProfileName            string `json:"profileName"`            // Friendly name of the 802.1X profile.
+	AuthenticationProtocol int    `json:"authenticationProtocol"` // 0 = EAP-TLS, 2 = PEAPv0/EAP-MSCHAPv2.
+	Username               string `json:"username"`               // 802.1X identity/username.
+	Password               string `json:"password"`               // Required for PEAPv0/EAP-MSCHAPv2 (protocol 2).
+	PrivateKey             string `json:"privateKey"`             // PEM-encoded private key. Required for EAP-TLS (protocol 0).
+	ClientCert             string `json:"clientCert"`             // PEM-encoded client certificate. Required for EAP-TLS (protocol 0).
+	CACert                 string `json:"caCert"`                 // PEM-encoded CA certificate.
+}
+
 type WirelessNetworkInfo struct {
 	NetworkInfo
 	WiFiNetworks          []WiFiNetwork         `json:"wifiNetworks"`

--- a/internal/mocks/devicemanagement_mocks.go
+++ b/internal/mocks/devicemanagement_mocks.go
@@ -941,6 +941,21 @@ func (mr *MockDeviceManagementFeatureMockRecorder) GetWirelessProfiles(c, guid a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWirelessProfiles), c, guid)
 }
 
+// GetWiredNetworkSettings mocks base method.
+func (m *MockDeviceManagementFeature) GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWiredNetworkSettings", c, guid)
+	ret0, _ := ret[0].(dto.WiredNetworkInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWiredNetworkSettings indicates an expected call of GetWiredNetworkSettings.
+func (mr *MockDeviceManagementFeatureMockRecorder) GetWiredNetworkSettings(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWiredNetworkSettings", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWiredNetworkSettings), c, guid)
+}
+
 // GetWirelessState mocks base method.
 func (m *MockDeviceManagementFeature) GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error) {
 	m.ctrl.T.Helper()
@@ -969,6 +984,20 @@ func (m *MockDeviceManagementFeature) Insert(ctx context.Context, d *dto.Device)
 func (mr *MockDeviceManagementFeatureMockRecorder) Insert(ctx, d any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockDeviceManagementFeature)(nil).Insert), ctx, d)
+}
+
+// PatchWiredNetworkSettings mocks base method.
+func (m *MockDeviceManagementFeature) PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchWiredNetworkSettings", c, guid, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWiredNetworkSettings indicates an expected call of PatchWiredNetworkSettings.
+func (mr *MockDeviceManagementFeatureMockRecorder) PatchWiredNetworkSettings(c, guid, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWiredNetworkSettings", reflect.TypeOf((*MockDeviceManagementFeature)(nil).PatchWiredNetworkSettings), c, guid, req)
 }
 
 // Redirect mocks base method.

--- a/internal/mocks/wsman_mocks.go
+++ b/internal/mocks/wsman_mocks.go
@@ -18,6 +18,7 @@ import (
 	alarmclock "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/alarmclock"
 	auditlog "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/auditlog"
 	boot "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
+	ethernetport "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	messagelog "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/messagelog"
 	redirection "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/redirection"
 	setupandconfiguration "github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
@@ -437,6 +438,21 @@ func (mr *MockManagementMockRecorder) GetDiskInfo() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDiskInfo", reflect.TypeOf((*MockManagement)(nil).GetDiskInfo))
 }
 
+// GetEthernetPortSettings mocks base method.
+func (m *MockManagement) GetEthernetPortSettings() ([]ethernetport.SettingsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetEthernetPortSettings")
+	ret0, _ := ret[0].([]ethernetport.SettingsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetEthernetPortSettings indicates an expected call of GetEthernetPortSettings.
+func (mr *MockManagementMockRecorder) GetEthernetPortSettings() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEthernetPortSettings", reflect.TypeOf((*MockManagement)(nil).GetEthernetPortSettings))
+}
+
 // GetEventLog mocks base method.
 func (m *MockManagement) GetEventLog(startIndex, maxReadRecords int) (messagelog.GetRecordsResponse, error) {
 	m.ctrl.T.Helper()
@@ -705,6 +721,21 @@ func (m *MockManagement) PullWiFiPort(enumerationContext string) (wifi.Response,
 func (mr *MockManagementMockRecorder) PullWiFiPort(enumerationContext any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PullWiFiPort", reflect.TypeOf((*MockManagement)(nil).PullWiFiPort), enumerationContext)
+}
+
+// PutEthernetPortSettings mocks base method.
+func (m *MockManagement) PutEthernetPortSettings(ethernetPortSettings ethernetport.SettingsRequest, instanceID string) (ethernetport.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutEthernetPortSettings", ethernetPortSettings, instanceID)
+	ret0, _ := ret[0].(ethernetport.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutEthernetPortSettings indicates an expected call of PutEthernetPortSettings.
+func (mr *MockManagementMockRecorder) PutEthernetPortSettings(ethernetPortSettings, instanceID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutEthernetPortSettings", reflect.TypeOf((*MockManagement)(nil).PutEthernetPortSettings), ethernetPortSettings, instanceID)
 }
 
 // RequestAMTRedirectionServiceStateChange mocks base method.

--- a/internal/mocks/wsv1_mocks.go
+++ b/internal/mocks/wsv1_mocks.go
@@ -602,6 +602,21 @@ func (mr *MockFeatureMockRecorder) GetWirelessProfiles(c, guid any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockFeature)(nil).GetWirelessProfiles), c, guid)
 }
 
+// GetWiredNetworkSettings mocks base method.
+func (m *MockFeature) GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWiredNetworkSettings", c, guid)
+	ret0, _ := ret[0].(dto.WiredNetworkInfo)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWiredNetworkSettings indicates an expected call of GetWiredNetworkSettings.
+func (mr *MockFeatureMockRecorder) GetWiredNetworkSettings(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWiredNetworkSettings", reflect.TypeOf((*MockFeature)(nil).GetWiredNetworkSettings), c, guid)
+}
+
 // GetWirelessState mocks base method.
 func (m *MockFeature) GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error) {
 	m.ctrl.T.Helper()
@@ -630,6 +645,20 @@ func (m *MockFeature) Insert(ctx context.Context, d *dto.Device) (*dto.Device, e
 func (mr *MockFeatureMockRecorder) Insert(ctx, d any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Insert", reflect.TypeOf((*MockFeature)(nil).Insert), ctx, d)
+}
+
+// PatchWiredNetworkSettings mocks base method.
+func (m *MockFeature) PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PatchWiredNetworkSettings", c, guid, req)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PatchWiredNetworkSettings indicates an expected call of PatchWiredNetworkSettings.
+func (mr *MockFeatureMockRecorder) PatchWiredNetworkSettings(c, guid, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PatchWiredNetworkSettings", reflect.TypeOf((*MockFeature)(nil).PatchWiredNetworkSettings), c, guid, req)
 }
 
 // Redirect mocks base method.

--- a/internal/usecase/devices/interfaces.go
+++ b/internal/usecase/devices/interfaces.go
@@ -82,6 +82,8 @@ type (
 		GetEventLog(ctx context.Context, startIndex, maxReadRecords int, guid string) (dto.EventLogs, error)
 		Redirect(ctx context.Context, conn *websocket.Conn, guid, mode string) error
 		GetNetworkSettings(c context.Context, guid string) (dto.NetworkSettings, error)
+		GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error)
+		PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error
 		RequestWirelessStateChange(c context.Context, guid string, requestedState wifi.RequestedState) (wifi.RequestedState, error)
 		GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error)
 		GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error)

--- a/internal/usecase/devices/network.go
+++ b/internal/usecase/devices/network.go
@@ -10,6 +10,12 @@ import (
 	"github.com/device-management-toolkit/console/internal/usecase/devices/wsman"
 )
 
+// Instance ID substrings that identify the AMT ethernet port interfaces.
+const (
+	wiredEthernetInstanceID    = "Intel(r) AMT Ethernet Port Settings 0"
+	wirelessEthernetInstanceID = "Intel(r) AMT Ethernet Port Settings 1"
+)
+
 func (uc *UseCase) GetNetworkSettings(c context.Context, guid string) (dto.NetworkSettings, error) {
 	item, err := uc.repo.GetByID(c, guid, "")
 	if err != nil {
@@ -35,7 +41,7 @@ func (uc *UseCase) GetNetworkSettings(c context.Context, guid string) (dto.Netwo
 	for i := range response.EthernetPortSettingsResult {
 		portSetting := &response.EthernetPortSettingsResult[i]
 
-		if strings.Contains(portSetting.InstanceID, "Intel(r) AMT Ethernet Port Settings 0") {
+		if strings.Contains(portSetting.InstanceID, wiredEthernetInstanceID) {
 			// Wired network
 			ns.Wired = &dto.WiredNetworkInfo{
 				IEEE8021x: dto.IEEE8021x{
@@ -47,7 +53,7 @@ func (uc *UseCase) GetNetworkSettings(c context.Context, guid string) (dto.Netwo
 			ns.Wired.NetworkInfo = convertToNetworkInfo(*portSetting)
 		}
 
-		if strings.Contains(portSetting.InstanceID, "Intel(r) AMT Ethernet Port Settings 1") {
+		if strings.Contains(portSetting.InstanceID, wirelessEthernetInstanceID) {
 			// Wireless network
 			ns.Wireless = &dto.WirelessNetworkInfo{}
 			ns.Wireless.NetworkInfo = convertToNetworkInfo(*portSetting)
@@ -151,4 +157,186 @@ func (uc *UseCase) processIEEE8021xSettings(response wsman.NetworkResults) []dto
 	}
 
 	return ieee8021xSettings
+}
+
+// GetWiredNetworkSettings returns the wired (Intel® AMT Ethernet Port Settings 0)
+// portion of a device's network settings.
+func (uc *UseCase) GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error) {
+	ns, err := uc.GetNetworkSettings(c, guid)
+	if err != nil {
+		return dto.WiredNetworkInfo{}, err
+	}
+
+	if ns.Wired == nil {
+		return dto.WiredNetworkInfo{}, ErrNotFound
+	}
+
+	return *ns.Wired, nil
+}
+
+// PatchWiredNetworkSettings updates a device's wired IPv4 configuration (DHCP or
+// static IP). It returns no content on success.
+func (uc *UseCase) PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error {
+	// Wired 802.1X configuration is a forward-looking API contract that is not yet
+	// implemented. Reject requests that supply the ieee8021x object rather than
+	// silently ignoring it, so the behavior is unambiguous for clients.
+	if req.IEEE8021x != nil {
+		return ErrNotSupportedUseCase.Wrap("PatchWiredNetworkSettings", "ieee8021x", "wired 802.1X configuration is not yet supported")
+	}
+
+	if err := validateWiredNetworkConfig(req); err != nil {
+		return err
+	}
+
+	item, err := uc.repo.GetByID(c, guid, "")
+	if err != nil {
+		return err
+	}
+
+	if item == nil || item.GUID == "" {
+		return ErrNotFound
+	}
+
+	device, err := uc.device.SetupWsmanClient(c, *item, false, true)
+	if err != nil {
+		return err
+	}
+
+	settings, err := device.GetEthernetPortSettings()
+	if err != nil {
+		return err
+	}
+
+	var current *ethernetport.SettingsResponse
+
+	for i := range settings {
+		if strings.Contains(settings[i].InstanceID, wiredEthernetInstanceID) {
+			current = &settings[i]
+
+			break
+		}
+	}
+
+	if current == nil {
+		return ErrNotFound
+	}
+
+	settingsRequest := buildWiredSettingsRequest(*current, req)
+
+	if _, err = device.PutEthernetPortSettings(settingsRequest, current.InstanceID); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// validateWiredNetworkConfig enforces the DHCP vs static-IP combination rules that
+// cannot be expressed with field-level binding tags.
+func validateWiredNetworkConfig(req dto.WiredNetworkConfigRequest) error {
+	dhcpEnabled := req.DHCPEnabled != nil && *req.DHCPEnabled
+	ipSyncEnabled := req.IPSyncEnabled != nil && *req.IPSyncEnabled
+	staticIPProvided := hasStaticIPSettings(req)
+
+	if dhcpEnabled && staticIPProvided {
+		return ErrValidationUseCase.Wrap("PatchWiredNetworkSettings", "validate", "cannot specify static IP settings when DHCP is enabled")
+	}
+
+	if ipSyncEnabled && staticIPProvided {
+		return ErrValidationUseCase.Wrap("PatchWiredNetworkSettings", "validate", "cannot specify static IP settings when IP sync is enabled")
+	}
+
+	if !dhcpEnabled && !ipSyncEnabled && !staticIPProvided {
+		return ErrValidationUseCase.Wrap("PatchWiredNetworkSettings", "validate", "must enable DHCP, enable IP sync, or provide static IP settings")
+	}
+
+	if !dhcpEnabled && staticIPProvided {
+		return validateStaticIPFields(req)
+	}
+
+	return nil
+}
+
+// hasStaticIPSettings reports whether the request supplies any static IPv4 field.
+func hasStaticIPSettings(req dto.WiredNetworkConfigRequest) bool {
+	return req.IPAddress != "" || req.SubnetMask != "" ||
+		req.DefaultGateway != "" || req.PrimaryDNS != "" || req.SecondaryDNS != ""
+}
+
+// validateStaticIPFields ensures the fields required for a static IP
+// configuration are present.
+func validateStaticIPFields(req dto.WiredNetworkConfigRequest) error {
+	required := []struct {
+		value string
+		name  string
+	}{
+		{req.IPAddress, "ipAddress"},
+		{req.SubnetMask, "subnetMask"},
+		{req.DefaultGateway, "defaultGateway"},
+		{req.PrimaryDNS, "primaryDNS"},
+	}
+
+	for _, field := range required {
+		if field.value == "" {
+			return ErrValidationUseCase.Wrap("PatchWiredNetworkSettings", "validate", field.name+" is required for static IP configuration")
+		}
+	}
+
+	return nil
+}
+
+// buildWiredSettingsRequest builds an ethernet port settings Put request by
+// overlaying the requested IPv4 changes on top of the device's current settings.
+func buildWiredSettingsRequest(current ethernetport.SettingsResponse, req dto.WiredNetworkConfigRequest) ethernetport.SettingsRequest {
+	settingsRequest := ethernetport.SettingsRequest{
+		XMLName:        current.XMLName,
+		ElementName:    current.ElementName,
+		InstanceID:     current.InstanceID,
+		SharedMAC:      current.SharedMAC,
+		SharedStaticIp: current.SharedStaticIp,
+		IpSyncEnabled:  current.IpSyncEnabled,
+		DHCPEnabled:    current.DHCPEnabled,
+		IPAddress:      current.IPAddress,
+		SubnetMask:     current.SubnetMask,
+		DefaultGateway: current.DefaultGateway,
+		PrimaryDNS:     current.PrimaryDNS,
+		SecondaryDNS:   current.SecondaryDNS,
+	}
+
+	if req.DHCPEnabled != nil && *req.DHCPEnabled {
+		// DHCP mode: AMT acquires IP settings, host/ME stay in sync.
+		settingsRequest.DHCPEnabled = true
+		settingsRequest.IpSyncEnabled = true
+		settingsRequest.SharedStaticIp = false
+	} else {
+		// Static IP mode.
+		settingsRequest.DHCPEnabled = false
+
+		ipSyncEnabled := current.IpSyncEnabled
+		if req.IPSyncEnabled != nil {
+			ipSyncEnabled = *req.IPSyncEnabled
+		}
+
+		// SharedStaticIp always follows IpSyncEnabled; the AMT firmware does not
+		// support sharing a static IP without host sync.
+		settingsRequest.IpSyncEnabled = ipSyncEnabled
+		settingsRequest.SharedStaticIp = ipSyncEnabled
+
+		settingsRequest.IPAddress = req.IPAddress
+		settingsRequest.SubnetMask = req.SubnetMask
+		settingsRequest.DefaultGateway = req.DefaultGateway
+		settingsRequest.PrimaryDNS = req.PrimaryDNS
+		settingsRequest.SecondaryDNS = req.SecondaryDNS
+	}
+
+	// When IP settings come from DHCP or are synced with the host, AMT rejects
+	// explicit IP fields, so they must be cleared.
+	if settingsRequest.IpSyncEnabled || settingsRequest.DHCPEnabled {
+		settingsRequest.IPAddress = ""
+		settingsRequest.SubnetMask = ""
+		settingsRequest.DefaultGateway = ""
+		settingsRequest.PrimaryDNS = ""
+		settingsRequest.SecondaryDNS = ""
+	}
+
+	return settingsRequest
 }

--- a/internal/usecase/devices/network_test.go
+++ b/internal/usecase/devices/network_test.go
@@ -188,3 +188,437 @@ func TestGetNetworkSettings(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWiredNetworkSettings(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{
+		GUID:     "device-guid-123",
+		TenantID: "tenant-id-456",
+	}
+
+	wiredResult := wsman.NetworkResults{
+		EthernetPortSettingsResult: []ethernetport.SettingsResponse{
+			{
+				ElementName: "Intel(r) AMT Ethernet Port Settings",
+				InstanceID:  "Intel(r) AMT Ethernet Port Settings 0",
+				DHCPEnabled: true,
+				IPAddress:   "192.168.1.10",
+			},
+		},
+		IPSIEEE8021xSettingsResult: ieee8021x.IEEE8021xSettingsResponse{Enabled: 3},
+	}
+
+	wirelessOnlyResult := wsman.NetworkResults{
+		EthernetPortSettingsResult: []ethernetport.SettingsResponse{
+			{
+				ElementName: "Intel(r) AMT Ethernet Port Settings",
+				InstanceID:  "Intel(r) AMT Ethernet Port Settings 1",
+			},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		manMock  func(*mocks.MockWSMAN, *mocks.MockManagement)
+		repoMock func(*mocks.MockDeviceManagementRepository)
+		res      dto.WiredNetworkInfo
+		err      error
+	}{
+		{
+			name: "success",
+			manMock: func(man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetNetworkSettings().
+					Return(wiredResult, nil)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			res: dto.WiredNetworkInfo{
+				IEEE8021x: dto.IEEE8021x{Enabled: "Disabled"},
+				NetworkInfo: dto.NetworkInfo{
+					ElementName:            "Intel(r) AMT Ethernet Port Settings",
+					InstanceID:             "Intel(r) AMT Ethernet Port Settings 0",
+					DHCPEnabled:            true,
+					IPAddress:              "192.168.1.10",
+					PhysicalConnectionType: "Integrated LAN NIC",
+					PhysicalNicMedium:      "SMBUS",
+				},
+			},
+			err: nil,
+		},
+		{
+			name: "no wired interface returns not found",
+			manMock: func(man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetNetworkSettings().
+					Return(wirelessOnlyResult, nil)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			res: dto.WiredNetworkInfo{},
+			err: devices.ErrNotFound,
+		},
+		{
+			name: "GetById fails",
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(nil, ErrGeneral)
+			},
+			res: dto.WiredNetworkInfo{},
+			err: devices.ErrGeneral,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			useCase, wsmanMock, management, repo := initNetworkTest(t)
+
+			if tc.manMock != nil {
+				tc.manMock(wsmanMock, management)
+			}
+
+			tc.repoMock(repo)
+
+			res, err := useCase.GetWiredNetworkSettings(context.Background(), device.GUID)
+
+			require.Equal(t, tc.res, res)
+			require.IsType(t, tc.err, err)
+		})
+	}
+}
+
+func TestPatchWiredNetworkSettings(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{
+		GUID:     "device-guid-123",
+		TenantID: "tenant-id-456",
+	}
+
+	currentSettings := []ethernetport.SettingsResponse{
+		{
+			ElementName: "Intel(r) AMT Ethernet Port Settings",
+			InstanceID:  "Intel(r) AMT Ethernet Port Settings 0",
+			DHCPEnabled: false,
+			IPAddress:   "192.168.1.10",
+		},
+	}
+
+	dhcpTrue := true
+	dhcpFalse := false
+
+	tests := []struct {
+		name     string
+		req      dto.WiredNetworkConfigRequest
+		manMock  func(*testing.T, *mocks.MockWSMAN, *mocks.MockManagement)
+		repoMock func(*mocks.MockDeviceManagementRepository)
+		err      error
+	}{
+		{
+			name: "success switch to dhcp",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(t *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				t.Helper()
+
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return(currentSettings, nil)
+				man2.EXPECT().
+					PutEthernetPortSettings(gomock.Any(), "Intel(r) AMT Ethernet Port Settings 0").
+					DoAndReturn(func(req ethernetport.SettingsRequest, _ string) (ethernetport.Response, error) {
+						// DHCP mode: AMT acquires its IPv4 config, host sync is forced
+						// on, and any explicit IP fields must be cleared.
+						require.True(t, req.DHCPEnabled)
+						require.True(t, req.IpSyncEnabled)
+						require.False(t, req.SharedStaticIp)
+						require.Empty(t, req.IPAddress)
+						require.Empty(t, req.SubnetMask)
+						require.Empty(t, req.DefaultGateway)
+						require.Empty(t, req.PrimaryDNS)
+						require.Empty(t, req.SecondaryDNS)
+
+						return ethernetport.Response{}, nil
+					})
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: nil,
+		},
+		{
+			name:     "validation error dhcp with static ip",
+			req:      dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue, IPAddress: "192.168.1.5"},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name:     "validation error ip sync with static ip",
+			req:      dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpFalse, IPSyncEnabled: &dhcpTrue, IPAddress: "192.168.1.5"},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name: "not supported ieee8021x provided",
+			req: dto.WiredNetworkConfigRequest{
+				DHCPEnabled: &dhcpTrue,
+				IEEE8021x:   &dto.WiredIEEE8021xConfig{ProfileName: "wired-eap"},
+			},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrNotSupportedUseCase,
+		},
+		{
+			name:     "validation error nothing requested",
+			req:      dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpFalse},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name:     "validation error static missing subnet",
+			req:      dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpFalse, IPAddress: "192.168.1.5"},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name: "validation error static missing gateway",
+			req: dto.WiredNetworkConfigRequest{
+				DHCPEnabled: &dhcpFalse,
+				IPAddress:   "192.168.1.5",
+				SubnetMask:  "255.255.255.0",
+			},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name: "validation error static missing primary dns",
+			req: dto.WiredNetworkConfigRequest{
+				DHCPEnabled:    &dhcpFalse,
+				IPAddress:      "192.168.1.5",
+				SubnetMask:     "255.255.255.0",
+				DefaultGateway: "192.168.1.1",
+			},
+			manMock:  func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {},
+			repoMock: func(_ *mocks.MockDeviceManagementRepository) {},
+			err:      devices.ErrValidationUseCase,
+		},
+		{
+			name: "success static ip",
+			req: dto.WiredNetworkConfigRequest{
+				DHCPEnabled:    &dhcpFalse,
+				IPAddress:      "192.168.1.5",
+				SubnetMask:     "255.255.255.0",
+				DefaultGateway: "192.168.1.1",
+				PrimaryDNS:     "192.168.1.1",
+			},
+			manMock: func(t *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				t.Helper()
+
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return(currentSettings, nil)
+				man2.EXPECT().
+					PutEthernetPortSettings(gomock.Any(), "Intel(r) AMT Ethernet Port Settings 0").
+					DoAndReturn(func(req ethernetport.SettingsRequest, _ string) (ethernetport.Response, error) {
+						// Manual static IP: ip sync inherited from current (false),
+						// so the supplied IP fields are carried through unchanged.
+						require.False(t, req.DHCPEnabled)
+						require.False(t, req.IpSyncEnabled)
+						require.False(t, req.SharedStaticIp)
+						require.Equal(t, "192.168.1.5", req.IPAddress)
+						require.Equal(t, "255.255.255.0", req.SubnetMask)
+						require.Equal(t, "192.168.1.1", req.DefaultGateway)
+						require.Equal(t, "192.168.1.1", req.PrimaryDNS)
+
+						return ethernetport.Response{}, nil
+					})
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: nil,
+		},
+		{
+			name: "GetById fails",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(nil, ErrGeneral)
+			},
+			err: devices.ErrGeneral,
+		},
+		{
+			name: "no wired interface",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return([]ethernetport.SettingsResponse{}, nil)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: devices.ErrNotFound,
+		},
+		{
+			name: "device not found nil item",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(nil, nil)
+			},
+			err: devices.ErrNotFound,
+		},
+		{
+			name: "SetupWsmanClient fails",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, man *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(nil, ErrGeneral)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: ErrGeneral,
+		},
+		{
+			name: "GetEthernetPortSettings fails",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return(nil, ErrGeneral)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: ErrGeneral,
+		},
+		{
+			name: "PutEthernetPortSettings fails",
+			req:  dto.WiredNetworkConfigRequest{DHCPEnabled: &dhcpTrue},
+			manMock: func(_ *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return(currentSettings, nil)
+				man2.EXPECT().
+					PutEthernetPortSettings(gomock.Any(), "Intel(r) AMT Ethernet Port Settings 0").
+					Return(ethernetport.Response{}, ErrGeneral)
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: ErrGeneral,
+		},
+		{
+			name: "success static ip with host sync enabled",
+			req: dto.WiredNetworkConfigRequest{
+				DHCPEnabled:   &dhcpFalse,
+				IPSyncEnabled: &dhcpTrue,
+			},
+			manMock: func(t *testing.T, man *mocks.MockWSMAN, man2 *mocks.MockManagement) {
+				t.Helper()
+
+				man.EXPECT().
+					SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).
+					Return(man2, nil)
+				man2.EXPECT().
+					GetEthernetPortSettings().
+					Return(currentSettings, nil)
+				man2.EXPECT().
+					PutEthernetPortSettings(gomock.Any(), "Intel(r) AMT Ethernet Port Settings 0").
+					DoAndReturn(func(req ethernetport.SettingsRequest, _ string) (ethernetport.Response, error) {
+						// Host-synced static IP: SharedStaticIp follows IpSyncEnabled
+						// and the explicit IP fields are cleared because they are
+						// supplied by the host OS.
+						require.False(t, req.DHCPEnabled)
+						require.True(t, req.IpSyncEnabled)
+						require.True(t, req.SharedStaticIp)
+						require.Empty(t, req.IPAddress)
+						require.Empty(t, req.SubnetMask)
+						require.Empty(t, req.DefaultGateway)
+						require.Empty(t, req.PrimaryDNS)
+
+						return ethernetport.Response{}, nil
+					})
+			},
+			repoMock: func(repo *mocks.MockDeviceManagementRepository) {
+				repo.EXPECT().
+					GetByID(context.Background(), device.GUID, "").
+					Return(device, nil)
+			},
+			err: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			useCase, wsmanMock, management, repo := initNetworkTest(t)
+
+			tc.manMock(t, wsmanMock, management)
+			tc.repoMock(repo)
+
+			err := useCase.PatchWiredNetworkSettings(context.Background(), device.GUID, tc.req)
+
+			require.IsType(t, tc.err, err)
+		})
+	}
+}

--- a/internal/usecase/devices/wsman/interfaces.go
+++ b/internal/usecase/devices/wsman/interfaces.go
@@ -7,6 +7,7 @@ import (
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/alarmclock"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/auditlog"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/ethernetport"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/messagelog"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/redirection"
 	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/setupandconfiguration"
@@ -63,6 +64,8 @@ type Management interface {
 	GetAuditLog(startIndex int) (auditlog.Response, error)
 	GetEventLog(startIndex, maxReadRecords int) (messagelog.GetRecordsResponse, error)
 	GetNetworkSettings() (NetworkResults, error)
+	GetEthernetPortSettings() ([]ethernetport.SettingsResponse, error)
+	PutEthernetPortSettings(ethernetPortSettings ethernetport.SettingsRequest, instanceID string) (ethernetport.Response, error)
 	GetWiFiSettings() ([]wifi.WiFiEndpointSettingsResponse, error)
 	GetCIMIEEE8021xSettings() (cimIEEE8021x.Response, error)
 	DeleteWiFiSetting(instanceID string) error


### PR DESCRIPTION
Add GET and PATCH /api/v1/amt/networkSettings/wired/:guid so callers can read and update a device's wired IPv4 configuration (DHCP or static IP) without touching the combined networkSettings payload.

The use case reuses GetNetworkSettings to read the wired port, then overlays the requested changes onto the current AMT Ethernet Port Settings 0 and issues a single Put. Static IP mode requires ipAddress, subnetMask, defaultGateway and primaryDNS; DHCP and IP-sync modes clear the explicit IP fields, matching AMT firmware rules.

Define a forward-looking ieee8021x request block on the patch DTO for future wired 802.1X support. It is not yet implemented: supplying the object returns 501 Not Implemented so the contract is stable and the later implementation is purely additive.

Wire the endpoints through the Gin handlers, the Fuego/OpenAPI declaration and the MPS Postman collection, regenerate mocks, and add use-case tests covering DHCP, static IP, validation errors and the not-supported 802.1X path.

Resolves: #837

NOTE:
> When changing to a static IP, it may take several seconds before Intel AMT responds to packets addressed to the new IP address. It is recommended to wait 10 seconds after changing to a static IP before attempting to communicate with the platform.
- The above note is quoted from [AMT SDK](https://software.intel.com/sites/manageability/AMT_Implementation_and_Reference_Guide/default.htm?turl=WordDocuments%2Fsetgetsynchronizedipsettings.htm), due to this limitation, it is expected that there will be few seconds device AMT down time after the configuration request, especially changing to a new static IP or pending for a new IP from DHCP server
- Developer guide: [console wiki](https://github.com/device-management-toolkit/console/wiki/Wired-Network-Settings-Architecture)

## Functional Test

Tested on-target using newman, test collections and environment file are as follow:
[wired_network.postman_collection.json](https://github.com/user-attachments/files/28641271/wired_network.postman_collection.json)
[wired_network.postman_environment.json](https://github.com/user-attachments/files/28641273/wired_network.postman_environment.json)

### Test Instructions

Pre-requisites:
- console app is running
- device provisioned and guid captured
- newman installed
- device host dhcp is enabled
- capture device ipAddress, subnetMask, defaultGateway, primaryDNS, secondaryDNS

```bash
# Modify the value of following keys in the environment file
# - protocol
# - host
# - consoleUser
# - consolePass
# - deviceId
# - ipAddress
# - subnetMask
# - defaultGateway
# - primaryDNS
# - secondaryDNS

# Execute newman test
newman run wired_network.postman_collection.json -e wired_network.postman_environment.json
```

### Test Coverage Summary

Total 22 test cases.

#### Negative — Binding (400)

| # | Case | Asserts |
|---|---|---|
| 08 | Missing `dhcpEnabled` (required) | 400 |
| 09 | Invalid `ipAddress` | 400 |
| 10 | Invalid `subnetMask` | 400 |
| 11 | Invalid `defaultGateway` | 400 |
| 12 | Invalid `primaryDNS` | 400 |
| 13 | Invalid `secondaryDNS` | 400 |
| 13b | IPv6 `ipAddress` rejected (IPv4-only contract) | 400 |

#### Negative — Validation (400)

| # | Case | Asserts |
|---|---|---|
| 14 | DHCP enabled + static IP | 400 |
| 15 | No mode chosen (`dhcpEnabled:false` only) | 400 |
| 16 | Static missing `ipAddress` | 400 |
| 17 | Static missing `subnetMask` | 400 |
| 18 | Static missing `defaultGateway` | 400 |
| 19 | Static missing `primaryDNS` | 400 |
| 20 | `secondaryDNS` only (triggers static, missing ipAddress) | 400 |
| 20b | IP sync enabled + static IP | 400 |

#### Negative — Not Supported 802.1X (501)

| # | Case | Asserts |
|---|---|---|
| 21 | `ieee8021x` EAP-TLS shape | 501 |
| 22 | `ieee8021x` PEAP + full static config | 501 |
| 23 | `ieee8021x` empty object (non-nil pointer) | 501 |

#### Positive (validation passes)

| # | Request | Asserts |
|---|---|---|
| 04 | Static IP (minimal) — PATCH | 204; not 400/501; empty body |
| 04 | Verify Static IP (GET after settle) | 200; well-formed body; `dhcpEnabled=false`, `ipSyncEnabled=false`; ip/subnet/gateway/primaryDNS echoed |
| 05 | Static IP + `secondaryDNS` — PATCH | 204; empty body |
| 05 | Verify (GET after settle) | 200; static applied; all 5 static fields incl. `secondaryDNS` echoed |
| 01 | DHCP (minimal) — PATCH | 204; empty body |
| 01 | Verify DHCP (GET after settle, 15s) | 200; well-formed; `dhcpEnabled=true` |
| 02 | DHCP (`ipSyncEnabled` ignored) — PATCH | 204; empty body |
| 02 | Verify DHCP (GET after settle) | 200; `dhcpEnabled=true` |

NOTE: the static IP sync(DHCP disabled, IP sync enabled) case is not covered in this test suite, as it requires the device host dhcp to be disabled, however, it was covered using manual steps