### PR TITLE
feat(api): add wireless local and UEFI profile sync endpoints

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -1055,6 +1055,103 @@
 					"response": []
 				},
 				{
+					"name": "Get Wireless Profile Sync",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {\r",
+									"    pm.response.to.have.status(404);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Device should not be found\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.error).to.eq(\"Error not found\")\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/amt/networkSettings/wireless/profileSync/{{deviceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"amt",
+								"networkSettings",
+								"wireless",
+								"profileSync",
+								"{{deviceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Set Wireless Profile Sync",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 404\", function () {\r",
+									"    pm.response.to.have.status(404);\r",
+									"});\r",
+									"\r",
+									"pm.test(\"Device should not be found\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.error).to.eq(\"Error not found\")\r",
+									"});\r",
+									""
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"localProfileSync\": true,\r\n    \"uefiProfileSync\": false\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/amt/networkSettings/wireless/profileSync/{{deviceId}}",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"amt",
+								"networkSettings",
+								"wireless",
+								"profileSync",
+								"{{deviceId}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Get Wireless Profiles",
 					"event": [
 						{

--- a/internal/controller/httpapi/v1/devicemanagement.go
+++ b/internal/controller/httpapi/v1/devicemanagement.go
@@ -54,6 +54,8 @@ func NewAmtRoutes(handler *gin.RouterGroup, d devices.Feature, amt amtexplorer.F
 		h.PATCH("networkSettings/wired/:guid", r.patchWiredNetworkSettings)
 		h.GET("networkSettings/wireless/state/:guid", r.getWirelessState)
 		h.POST("networkSettings/wireless/state/:guid", r.requestWirelessStateChange)
+		h.GET("networkSettings/wireless/profileSync/:guid", r.getWirelessProfileSync)
+		h.POST("networkSettings/wireless/profileSync/:guid", r.setWirelessProfileSync)
 		h.GET("networkSettings/wireless/profile/:guid", r.getWirelessProfiles)
 		h.POST("networkSettings/wireless/profile/:guid", r.addWirelessProfile)
 		h.PATCH("networkSettings/wireless/profile/:guid", r.updateWirelessProfile)

--- a/internal/controller/httpapi/v1/wifiprofilesync.go
+++ b/internal/controller/httpapi/v1/wifiprofilesync.go
@@ -1,0 +1,77 @@
+package v1
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	"github.com/device-management-toolkit/console/internal/usecase/devices"
+	"github.com/device-management-toolkit/console/internal/usecase/devices/wsman"
+	"github.com/device-management-toolkit/console/pkg/consoleerrors"
+)
+
+var errValidationWirelessProfileSync = dto.NotValidError{Console: consoleerrors.CreateConsoleError("WirelessProfileSyncAPI")}
+
+func (r *deviceManagementRoutes) getWirelessProfileSync(c *gin.Context) {
+	guid := c.Param("guid")
+
+	response, err := r.d.GetWirelessProfileSync(c.Request.Context(), guid)
+	if err != nil {
+		r.l.Error(err, "http - v1 - getWirelessProfileSync")
+
+		if errors.Is(err, wsman.ErrNoWiFiPort) {
+			c.JSON(http.StatusNotFound, gin.H{
+				errorKey: "Get Wireless Profile Sync failed for guid: " + guid + ". - " + err.Error(),
+			})
+
+			return
+		}
+
+		ErrorResponse(c, err)
+
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}
+
+func (r *deviceManagementRoutes) setWirelessProfileSync(c *gin.Context) {
+	guid := c.Param("guid")
+
+	var req dto.WirelessProfileSyncRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		validationErr := errValidationWirelessProfileSync.Wrap("setWirelessProfileSync", "ShouldBindJSON", err)
+		ErrorResponse(c, validationErr)
+
+		return
+	}
+
+	response, err := r.d.SetWirelessProfileSync(c.Request.Context(), guid, req)
+	if err != nil {
+		r.l.Error(err, "http - v1 - setWirelessProfileSync")
+
+		if errors.Is(err, wsman.ErrNoWiFiPort) {
+			c.JSON(http.StatusNotFound, gin.H{
+				errorKey: "Set Wireless Profile Sync failed for guid: " + guid + ". - " + err.Error(),
+			})
+
+			return
+		}
+
+		if errors.Is(err, devices.ErrUEFIProfileSyncNotSupported) {
+			c.JSON(http.StatusConflict, gin.H{
+				errorKey: "Set Wireless Profile Sync failed for guid: " + guid + ". - " + err.Error(),
+			})
+
+			return
+		}
+
+		ErrorResponse(c, err)
+
+		return
+	}
+
+	c.JSON(http.StatusOK, response)
+}

--- a/internal/controller/httpapi/v1/wifiprofilesync_test.go
+++ b/internal/controller/httpapi/v1/wifiprofilesync_test.go
@@ -1,0 +1,160 @@
+package v1
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	"github.com/device-management-toolkit/console/internal/mocks"
+	"github.com/device-management-toolkit/console/internal/usecase/devices"
+	"github.com/device-management-toolkit/console/internal/usecase/devices/wsman"
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+var errProfileSync = errors.New("profile sync failure")
+
+func TestWiFiProfileSyncHandlers(t *testing.T) {
+	t.Parallel()
+
+	gin.SetMode(gin.TestMode)
+
+	const path = "/api/v1/amt/networkSettings/wireless/profileSync/my-guid"
+
+	tests := []struct {
+		name       string
+		method     string
+		body       string
+		setupMock  func(devMock *mocks.MockDeviceManagementFeature)
+		wantStatus int
+		wantBody   string
+	}{
+		{
+			name:   "get wireless profile sync",
+			method: http.MethodGet,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					GetWirelessProfileSync(gomock.Any(), "my-guid").
+					Return(dto.WirelessProfileSyncResponse{LocalProfileSync: true, UEFIProfileSync: false, UEFIProfileSyncSupported: true}, nil)
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"localProfileSync":true,"uefiProfileSync":false,"uefiProfileSyncSupported":true}`,
+		},
+		{
+			name:   "get wireless profile sync - usecase error",
+			method: http.MethodGet,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					GetWirelessProfileSync(gomock.Any(), "my-guid").
+					Return(dto.WirelessProfileSyncResponse{}, errProfileSync)
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:   "get wireless profile sync - no wifi port",
+			method: http.MethodGet,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					GetWirelessProfileSync(gomock.Any(), "my-guid").
+					Return(dto.WirelessProfileSyncResponse{}, wsman.ErrNoWiFiPort)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:   "set wireless profile sync",
+			method: http.MethodPost,
+			body:   `{"localProfileSync":false,"uefiProfileSync":true}`,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					SetWirelessProfileSync(gomock.Any(), "my-guid", gomock.Any()).
+					Return(dto.WirelessProfileSyncResponse{LocalProfileSync: false, UEFIProfileSync: true, UEFIProfileSyncSupported: true}, nil)
+			},
+			wantStatus: http.StatusOK,
+			wantBody:   `{"localProfileSync":false,"uefiProfileSync":true,"uefiProfileSyncSupported":true}`,
+		},
+		{
+			name:       "set wireless profile sync - invalid payload",
+			method:     http.MethodPost,
+			body:       `{"localProfileSync":"not-a-bool"}`,
+			wantStatus: http.StatusBadRequest,
+		},
+		{
+			name:   "set wireless profile sync - usecase error",
+			method: http.MethodPost,
+			body:   `{"localProfileSync":true}`,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					SetWirelessProfileSync(gomock.Any(), "my-guid", gomock.Any()).
+					Return(dto.WirelessProfileSyncResponse{}, errProfileSync)
+			},
+			wantStatus: http.StatusInternalServerError,
+		},
+		{
+			name:   "set wireless profile sync - no wifi port",
+			method: http.MethodPost,
+			body:   `{"localProfileSync":true}`,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					SetWirelessProfileSync(gomock.Any(), "my-guid", gomock.Any()).
+					Return(dto.WirelessProfileSyncResponse{}, wsman.ErrNoWiFiPort)
+			},
+			wantStatus: http.StatusNotFound,
+		},
+		{
+			name:   "set wireless profile sync - uefi unsupported conflict",
+			method: http.MethodPost,
+			body:   `{"uefiProfileSync":true}`,
+			setupMock: func(devMock *mocks.MockDeviceManagementFeature) {
+				devMock.EXPECT().
+					SetWirelessProfileSync(gomock.Any(), "my-guid", gomock.Any()).
+					Return(dto.WirelessProfileSyncResponse{}, devices.ErrUEFIProfileSyncNotSupported)
+			},
+			wantStatus: http.StatusConflict,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mockCtl := gomock.NewController(t)
+			defer mockCtl.Finish()
+
+			devMock := mocks.NewMockDeviceManagementFeature(mockCtl)
+			if tc.setupMock != nil {
+				tc.setupMock(devMock)
+			}
+
+			engine := gin.New()
+			handler := engine.Group("/api/v1")
+			NewAmtRoutes(handler, devMock, nil, nil, logger.New("error"))
+
+			reqBody := io.Reader(http.NoBody)
+			if tc.body != "" {
+				reqBody = bytes.NewBufferString(tc.body)
+			}
+
+			req := httptest.NewRequest(tc.method, path, reqBody)
+			if tc.method == http.MethodPost {
+				req.Header.Set("Content-Type", "application/json")
+			}
+
+			w := httptest.NewRecorder()
+			engine.ServeHTTP(w, req)
+
+			require.Equal(t, tc.wantStatus, w.Code)
+
+			if tc.wantBody != "" {
+				require.JSONEq(t, tc.wantBody, w.Body.String())
+			}
+		})
+	}
+}

--- a/internal/controller/openapi/devicemanagement.go
+++ b/internal/controller/openapi/devicemanagement.go
@@ -23,7 +23,8 @@ func (f *FuegoAdapter) RegisterDeviceManagementRoutes() {
 
 func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 	// kvm displays
-	fuego.Get(f.server, "/api/v1/amt/kvm/displays/{guid}", f.getKVMDisplays,
+	fuego.Get(
+		f.server, "/api/v1/amt/kvm/displays/{guid}", f.getKVMDisplays,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get KVM displays"),
 		fuego.OptionDescription("Retrieve current KVM display settings for a device"),
@@ -31,7 +32,8 @@ func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Put(f.server, "/api/v1/amt/kvm/displays/{guid}", f.setKVMDisplays,
+	fuego.Put(
+		f.server, "/api/v1/amt/kvm/displays/{guid}", f.setKVMDisplays,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Set KVM displays"),
 		fuego.OptionDescription("Update KVM display settings for a device"),
@@ -40,7 +42,8 @@ func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 	)
 
 	// Certificates
-	fuego.Get(f.server, "/api/v1/amt/certificates/{guid}", f.getCertificates,
+	fuego.Get(
+		f.server, "/api/v1/amt/certificates/{guid}", f.getCertificates,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Certificates"),
 		fuego.OptionDescription("Retrieve certificate and key information for a device"),
@@ -48,7 +51,8 @@ func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/certificates/{guid}", f.addCertificate,
+	fuego.Post(
+		f.server, "/api/v1/amt/certificates/{guid}", f.addCertificate,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Add Certificate"),
 		fuego.OptionDescription("Add a certificate to the device"),
@@ -56,7 +60,8 @@ func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Delete(f.server, "/api/v1/amt/certificates/{guid}/{instanceId}", f.deleteCertificate,
+	fuego.Delete(
+		f.server, "/api/v1/amt/certificates/{guid}/{instanceId}", f.deleteCertificate,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Delete Certificate"),
 		fuego.OptionDescription("Delete a certificate from the device"),
@@ -69,14 +74,16 @@ func (f *FuegoAdapter) registerKVMAndCertificateRoutes() {
 
 func (f *FuegoAdapter) registerExplorerRoutes() {
 	// Explorer endpoints
-	fuego.Get(f.server, "/api/v1/amt/explorer", f.getCallList,
+	fuego.Get(
+		f.server, "/api/v1/amt/explorer", f.getCallList,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Explorer Calls"),
 		fuego.OptionDescription("Retrieve supported AMT explorer calls"),
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/explorer/{guid}/{call}", f.executeCall,
+	fuego.Get(
+		f.server, "/api/v1/amt/explorer/{guid}/{call}", f.executeCall,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Execute Explorer Call"),
 		fuego.OptionDescription("Execute an AMT explorer call on a device"),
@@ -88,7 +95,8 @@ func (f *FuegoAdapter) registerExplorerRoutes() {
 
 func (f *FuegoAdapter) registerNetworkRoutes() {
 	// TLS settings
-	fuego.Get(f.server, "/api/v1/amt/tls/{guid}", f.getTLSSettingData,
+	fuego.Get(
+		f.server, "/api/v1/amt/tls/{guid}", f.getTLSSettingData,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get TLS Setting Data"),
 		fuego.OptionDescription("Retrieve TLS setting data for a device"),
@@ -97,7 +105,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 	)
 
 	// Network settings
-	fuego.Get(f.server, "/api/v1/amt/networkSettings/{guid}", f.getNetworkSettings,
+	fuego.Get(
+		f.server, "/api/v1/amt/networkSettings/{guid}", f.getNetworkSettings,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Network Settings"),
 		fuego.OptionDescription("Retrieve network settings for a device"),
@@ -122,23 +131,12 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/networkSettings/wireless/state/{guid}", f.getWirelessState,
-		fuego.OptionTags("Device Management"),
-		fuego.OptionSummary("Get Wireless State"),
-		fuego.OptionDescription("Retrieve wireless state for a device"),
-		fuego.OptionPath("guid", "Device GUID"),
-		protectedRouteOptions(),
-	)
+	f.registerWirelessStateRoutes()
 
-	fuego.Post(f.server, "/api/v1/amt/networkSettings/wireless/state/{guid}", f.requestWirelessStateChange,
-		fuego.OptionTags("Device Management"),
-		fuego.OptionSummary("Request Wireless State Change"),
-		fuego.OptionDescription("Request a wireless state change for a device"),
-		fuego.OptionPath("guid", "Device GUID"),
-		protectedRouteOptions(),
-	)
+	f.registerWirelessProfileSyncRoutes()
 
-	fuego.Get(f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.getWirelessProfiles,
+	fuego.Get(
+		f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.getWirelessProfiles,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Wireless Profiles"),
 		fuego.OptionDescription("Retrieve configured wireless profiles for a device"),
@@ -146,7 +144,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.addWirelessProfile,
+	fuego.Post(
+		f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.addWirelessProfile,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Create Wireless Profile"),
 		fuego.OptionDescription("Create a wireless profile on a device"),
@@ -155,7 +154,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Patch(f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.updateWirelessProfile,
+	fuego.Patch(
+		f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}", f.updateWirelessProfile,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Update Wireless Profile"),
 		fuego.OptionDescription("Update a wireless profile on a device"),
@@ -164,7 +164,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Delete(f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}/{profileName}", f.deleteWirelessProfile,
+	fuego.Delete(
+		f.server, "/api/v1/amt/networkSettings/wireless/profile/{guid}/{profileName}", f.deleteWirelessProfile,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Delete Wireless Profile"),
 		fuego.OptionDescription("Delete a wireless profile from a device"),
@@ -174,7 +175,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/network/linkPreference/{guid}", f.setLinkPreference,
+	fuego.Post(
+		f.server, "/api/v1/amt/network/linkPreference/{guid}", f.setLinkPreference,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Set Link Preference"),
 		fuego.OptionDescription("Set network link preference on a device"),
@@ -185,7 +187,8 @@ func (f *FuegoAdapter) registerNetworkRoutes() {
 
 func (f *FuegoAdapter) registerFeatureRoutes() {
 	// Features
-	fuego.Get(f.server, "/api/v1/amt/features/{guid}", f.getFeatures,
+	fuego.Get(
+		f.server, "/api/v1/amt/features/{guid}", f.getFeatures,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Features"),
 		fuego.OptionDescription("Retrieve feature flags for a device"),
@@ -193,7 +196,8 @@ func (f *FuegoAdapter) registerFeatureRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/features/{guid}", f.setFeatures,
+	fuego.Post(
+		f.server, "/api/v1/amt/features/{guid}", f.setFeatures,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Set Features"),
 		fuego.OptionDescription("Update feature flags for a device"),
@@ -202,9 +206,52 @@ func (f *FuegoAdapter) registerFeatureRoutes() {
 	)
 }
 
+func (f *FuegoAdapter) registerWirelessStateRoutes() {
+	fuego.Get(
+		f.server, "/api/v1/amt/networkSettings/wireless/state/{guid}", f.getWirelessState,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Get Wireless State"),
+		fuego.OptionDescription("Retrieve wireless state for a device"),
+		fuego.OptionPath("guid", "Device GUID"),
+		protectedRouteOptions(),
+	)
+
+	fuego.Post(
+		f.server, "/api/v1/amt/networkSettings/wireless/state/{guid}", f.requestWirelessStateChange,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Request Wireless State Change"),
+		fuego.OptionDescription("Request a wireless state change for a device"),
+		fuego.OptionPath("guid", "Device GUID"),
+		protectedRouteOptions(),
+	)
+}
+
+func (f *FuegoAdapter) registerWirelessProfileSyncRoutes() {
+	fuego.Get(
+		f.server, "/api/v1/amt/networkSettings/wireless/profileSync/{guid}", f.getWirelessProfileSync,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Get Wireless Profile Sync"),
+		fuego.OptionDescription("Retrieve local and UEFI WiFi profile synchronization state, including whether UEFI sync is supported by the device"),
+		fuego.OptionPath("guid", "Device GUID"),
+		protectedRouteOptions(),
+	)
+
+	fuego.Post(
+		f.server, "/api/v1/amt/networkSettings/wireless/profileSync/{guid}", f.setWirelessProfileSync,
+		fuego.OptionTags("Device Management"),
+		fuego.OptionSummary("Set Wireless Profile Sync"),
+		fuego.OptionDescription("Enable or disable local and/or UEFI WiFi profile synchronization. Requesting UEFI sync on an unsupported device rejects the entire request with 409 Conflict"),
+		fuego.OptionPath("guid", "Device GUID"),
+		errorResponseOption(http.StatusBadRequest, "Bad Request"),
+		errorResponseOption(http.StatusConflict, "Conflict"),
+		protectedRouteOptions(),
+	)
+}
+
 func (f *FuegoAdapter) registerUserConsentRoutes() {
 	// User consent code
-	fuego.Get(f.server, "/api/v1/amt/userConsentCode/cancel/{guid}", f.cancelUserConsentCode,
+	fuego.Get(
+		f.server, "/api/v1/amt/userConsentCode/cancel/{guid}", f.cancelUserConsentCode,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Cancel User Consent Code"),
 		fuego.OptionDescription("Cancel a previously issued user consent code for a device"),
@@ -212,7 +259,8 @@ func (f *FuegoAdapter) registerUserConsentRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/userConsentCode/{guid}", f.getUserConsentCode,
+	fuego.Get(
+		f.server, "/api/v1/amt/userConsentCode/{guid}", f.getUserConsentCode,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get User Consent Code"),
 		fuego.OptionDescription("Retrieve the current user consent code for a device"),
@@ -220,7 +268,8 @@ func (f *FuegoAdapter) registerUserConsentRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/userConsentCode/{guid}", f.sendConsentCode,
+	fuego.Post(
+		f.server, "/api/v1/amt/userConsentCode/{guid}", f.sendConsentCode,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Send User Consent Code"),
 		fuego.OptionDescription("Send a user consent code to the device"),
@@ -231,7 +280,8 @@ func (f *FuegoAdapter) registerUserConsentRoutes() {
 
 func (f *FuegoAdapter) registerPowerRoutes() {
 	// Power endpoints
-	fuego.Get(f.server, "/api/v1/amt/power/state/{guid}", f.getPowerState,
+	fuego.Get(
+		f.server, "/api/v1/amt/power/state/{guid}", f.getPowerState,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Power State"),
 		fuego.OptionDescription("Retrieve the current power state of a device"),
@@ -239,7 +289,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/power/action/{guid}", f.powerAction,
+	fuego.Post(
+		f.server, "/api/v1/amt/power/action/{guid}", f.powerAction,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Perform Power Action"),
 		fuego.OptionDescription("Perform a power action on a device"),
@@ -247,7 +298,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/power/bootOptions/{guid}", f.setBootOptions,
+	fuego.Post(
+		f.server, "/api/v1/amt/power/bootOptions/{guid}", f.setBootOptions,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Set Boot Options"),
 		fuego.OptionDescription("Set boot options on a device"),
@@ -255,7 +307,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/power/bootoptions/{guid}", f.setBootOptions,
+	fuego.Post(
+		f.server, "/api/v1/amt/power/bootoptions/{guid}", f.setBootOptions,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Set Boot Options (alt path)"),
 		fuego.OptionDescription("Set boot options on a device (alternate path)"),
@@ -263,7 +316,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/power/bootSources/{guid}", f.getBootSources,
+	fuego.Get(
+		f.server, "/api/v1/amt/power/bootSources/{guid}", f.getBootSources,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Boot Sources"),
 		fuego.OptionDescription("Retrieve available boot sources for a device"),
@@ -271,7 +325,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/power/capabilities/{guid}", f.getPowerCapabilities,
+	fuego.Get(
+		f.server, "/api/v1/amt/power/capabilities/{guid}", f.getPowerCapabilities,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Power Capabilities"),
 		fuego.OptionDescription("Retrieve power capabilities for a device"),
@@ -282,7 +337,8 @@ func (f *FuegoAdapter) registerPowerRoutes() {
 
 func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 	// Audit and Event logs
-	fuego.Get(f.server, "/api/v1/amt/log/audit/{guid}", f.getAuditLog,
+	fuego.Get(
+		f.server, "/api/v1/amt/log/audit/{guid}", f.getAuditLog,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Audit Log"),
 		fuego.OptionDescription("Retrieve audit log entries for a device"),
@@ -291,7 +347,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/log/audit/{guid}/download", f.downloadAuditLog,
+	fuego.Get(
+		f.server, "/api/v1/amt/log/audit/{guid}/download", f.downloadAuditLog,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Download Audit Log"),
 		fuego.OptionDescription("Download audit logs as CSV for a device"),
@@ -300,7 +357,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/log/event/{guid}", f.getEventLog,
+	fuego.Get(
+		f.server, "/api/v1/amt/log/event/{guid}", f.getEventLog,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Event Log"),
 		fuego.OptionDescription("Retrieve event log entries for a device"),
@@ -311,7 +369,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Get(f.server, "/api/v1/amt/log/event/{guid}/download", f.downloadEventLog,
+	fuego.Get(
+		f.server, "/api/v1/amt/log/event/{guid}/download", f.downloadEventLog,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Download Event Log"),
 		fuego.OptionDescription("Download event logs as CSV for a device"),
@@ -321,7 +380,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 	)
 
 	// Alarm occurrences
-	fuego.Get(f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.getAlarmOccurrences,
+	fuego.Get(
+		f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.getAlarmOccurrences,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Alarm Occurrences"),
 		fuego.OptionDescription("Retrieve alarm occurrences for a device"),
@@ -329,7 +389,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Post(f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.createAlarmOccurrences,
+	fuego.Post(
+		f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.createAlarmOccurrences,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Create Alarm Occurrence"),
 		fuego.OptionDescription("Create an alarm occurrence on a device"),
@@ -338,7 +399,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 		protectedRouteOptions(),
 	)
 
-	fuego.Delete(f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.deleteAlarmOccurrences,
+	fuego.Delete(
+		f.server, "/api/v1/amt/alarmOccurrences/{guid}", f.deleteAlarmOccurrences,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Delete Alarm Occurrence"),
 		fuego.OptionDescription("Delete an alarm occurrence from a device"),
@@ -350,7 +412,8 @@ func (f *FuegoAdapter) registerLogsAndAlarmRoutes() {
 
 func (f *FuegoAdapter) registerVersionAndHardwareRoutes() {
 	// Version
-	fuego.Get(f.server, "/api/v1/amt/version/{guid}", f.getVersion,
+	fuego.Get(
+		f.server, "/api/v1/amt/version/{guid}", f.getVersion,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Version"),
 		fuego.OptionDescription("Retrieve AMT/software version information for a device"),
@@ -359,7 +422,8 @@ func (f *FuegoAdapter) registerVersionAndHardwareRoutes() {
 	)
 
 	// Hardware
-	fuego.Get(f.server, "/api/v1/amt/hardwareInfo/{guid}", f.getHardwareInfo,
+	fuego.Get(
+		f.server, "/api/v1/amt/hardwareInfo/{guid}", f.getHardwareInfo,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Hardware Info"),
 		fuego.OptionDescription("Retrieve hardware information for a device"),
@@ -368,7 +432,8 @@ func (f *FuegoAdapter) registerVersionAndHardwareRoutes() {
 	)
 
 	// Disk Info
-	fuego.Get(f.server, "/api/v1/amt/diskInfo/{guid}", f.getDiskInfo,
+	fuego.Get(
+		f.server, "/api/v1/amt/diskInfo/{guid}", f.getDiskInfo,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get Disk Info"),
 		fuego.OptionDescription("Retrieve disk information for a device"),
@@ -377,7 +442,8 @@ func (f *FuegoAdapter) registerVersionAndHardwareRoutes() {
 	)
 
 	// General Settings
-	fuego.Get(f.server, "/api/v1/amt/generalSettings/{guid}", f.getGeneralSettings,
+	fuego.Get(
+		f.server, "/api/v1/amt/generalSettings/{guid}", f.getGeneralSettings,
 		fuego.OptionTags("Device Management"),
 		fuego.OptionSummary("Get General Settings"),
 		fuego.OptionDescription("Retrieve general settings for a device"),
@@ -482,6 +548,19 @@ func (f *FuegoAdapter) requestWirelessStateChange(c fuego.ContextWithBody[dto.Wi
 	}
 
 	return dto.WirelessStateResponse(req), nil
+}
+
+func (f *FuegoAdapter) getWirelessProfileSync(_ fuego.ContextNoBody) (dto.WirelessProfileSyncResponse, error) {
+	return dto.WirelessProfileSyncResponse{}, nil
+}
+
+func (f *FuegoAdapter) setWirelessProfileSync(c fuego.ContextWithBody[dto.WirelessProfileSyncRequest]) (dto.WirelessProfileSyncResponse, error) {
+	_, err := c.Body()
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	return dto.WirelessProfileSyncResponse{}, nil
 }
 
 func (f *FuegoAdapter) getWirelessProfiles(_ fuego.ContextNoBody) ([]dto.WirelessProfileResponse, error) {

--- a/internal/controller/ws/v1/interface.go
+++ b/internal/controller/ws/v1/interface.go
@@ -64,6 +64,8 @@ type Feature interface {
 	PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error
 	RequestWirelessStateChange(c context.Context, guid string, requestedState wifi.RequestedState) (wifi.RequestedState, error)
 	GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error)
+	GetWirelessProfileSync(c context.Context, guid string) (dto.WirelessProfileSyncResponse, error)
+	SetWirelessProfileSync(c context.Context, guid string, req dto.WirelessProfileSyncRequest) (dto.WirelessProfileSyncResponse, error)
 	GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error)
 	AddWirelessProfile(c context.Context, guid string, profile config.WirelessProfile) error
 	DeleteWirelessProfile(c context.Context, guid, profileName string) error

--- a/internal/entity/dto/v1/wifiprofilesync.go
+++ b/internal/entity/dto/v1/wifiprofilesync.go
@@ -1,0 +1,12 @@
+package dto
+
+type WirelessProfileSyncRequest struct {
+	LocalProfileSync *bool `json:"localProfileSync"`
+	UEFIProfileSync  *bool `json:"uefiProfileSync"`
+}
+
+type WirelessProfileSyncResponse struct {
+	LocalProfileSync         bool `json:"localProfileSync"`
+	UEFIProfileSync          bool `json:"uefiProfileSync"`
+	UEFIProfileSyncSupported bool `json:"uefiProfileSyncSupported"`
+}

--- a/internal/mocks/devicemanagement_mocks.go
+++ b/internal/mocks/devicemanagement_mocks.go
@@ -926,21 +926,6 @@ func (mr *MockDeviceManagementFeatureMockRecorder) GetVersion(ctx, guid any) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetVersion), ctx, guid)
 }
 
-// GetWirelessProfiles mocks base method.
-func (m *MockDeviceManagementFeature) GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWirelessProfiles", c, guid)
-	ret0, _ := ret[0].([]dto.WirelessProfileResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetWirelessProfiles indicates an expected call of GetWirelessProfiles.
-func (mr *MockDeviceManagementFeatureMockRecorder) GetWirelessProfiles(c, guid any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWirelessProfiles), c, guid)
-}
-
 // GetWiredNetworkSettings mocks base method.
 func (m *MockDeviceManagementFeature) GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error) {
 	m.ctrl.T.Helper()
@@ -954,6 +939,36 @@ func (m *MockDeviceManagementFeature) GetWiredNetworkSettings(c context.Context,
 func (mr *MockDeviceManagementFeatureMockRecorder) GetWiredNetworkSettings(c, guid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWiredNetworkSettings", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWiredNetworkSettings), c, guid)
+}
+
+// GetWirelessProfileSync mocks base method.
+func (m *MockDeviceManagementFeature) GetWirelessProfileSync(c context.Context, guid string) (dto.WirelessProfileSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWirelessProfileSync", c, guid)
+	ret0, _ := ret[0].(dto.WirelessProfileSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWirelessProfileSync indicates an expected call of GetWirelessProfileSync.
+func (mr *MockDeviceManagementFeatureMockRecorder) GetWirelessProfileSync(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfileSync", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWirelessProfileSync), c, guid)
+}
+
+// GetWirelessProfiles mocks base method.
+func (m *MockDeviceManagementFeature) GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWirelessProfiles", c, guid)
+	ret0, _ := ret[0].([]dto.WirelessProfileResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWirelessProfiles indicates an expected call of GetWirelessProfiles.
+func (mr *MockDeviceManagementFeatureMockRecorder) GetWirelessProfiles(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockDeviceManagementFeature)(nil).GetWirelessProfiles), c, guid)
 }
 
 // GetWirelessState mocks base method.
@@ -1118,6 +1133,21 @@ func (m *MockDeviceManagementFeature) SetLinkPreference(c context.Context, guid 
 func (mr *MockDeviceManagementFeatureMockRecorder) SetLinkPreference(c, guid, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkPreference", reflect.TypeOf((*MockDeviceManagementFeature)(nil).SetLinkPreference), c, guid, req)
+}
+
+// SetWirelessProfileSync mocks base method.
+func (m *MockDeviceManagementFeature) SetWirelessProfileSync(c context.Context, guid string, req dto.WirelessProfileSyncRequest) (dto.WirelessProfileSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWirelessProfileSync", c, guid, req)
+	ret0, _ := ret[0].(dto.WirelessProfileSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetWirelessProfileSync indicates an expected call of SetWirelessProfileSync.
+func (mr *MockDeviceManagementFeatureMockRecorder) SetWirelessProfileSync(c, guid, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWirelessProfileSync", reflect.TypeOf((*MockDeviceManagementFeature)(nil).SetWirelessProfileSync), c, guid, req)
 }
 
 // Update mocks base method.

--- a/internal/mocks/wsman_mocks.go
+++ b/internal/mocks/wsman_mocks.go
@@ -678,6 +678,21 @@ func (mr *MockManagementMockRecorder) GetUserConsentCode() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserConsentCode", reflect.TypeOf((*MockManagement)(nil).GetUserConsentCode))
 }
 
+// GetWiFiPortConfigurationService mocks base method.
+func (m *MockManagement) GetWiFiPortConfigurationService() (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWiFiPortConfigurationService")
+	ret0, _ := ret[0].(wifiportconfiguration.WiFiPortConfigurationServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWiFiPortConfigurationService indicates an expected call of GetWiFiPortConfigurationService.
+func (mr *MockManagementMockRecorder) GetWiFiPortConfigurationService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWiFiPortConfigurationService", reflect.TypeOf((*MockManagement)(nil).GetWiFiPortConfigurationService))
+}
+
 // GetWiFiPorts mocks base method.
 func (m *MockManagement) GetWiFiPorts() ([]wifi.WiFiPort, error) {
 	m.ctrl.T.Helper()
@@ -736,6 +751,21 @@ func (m *MockManagement) PutEthernetPortSettings(ethernetPortSettings ethernetpo
 func (mr *MockManagementMockRecorder) PutEthernetPortSettings(ethernetPortSettings, instanceID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutEthernetPortSettings", reflect.TypeOf((*MockManagement)(nil).PutEthernetPortSettings), ethernetPortSettings, instanceID)
+}
+
+// PutWiFiPortConfigurationService mocks base method.
+func (m *MockManagement) PutWiFiPortConfigurationService(request wifiportconfiguration.WiFiPortConfigurationServiceRequest) (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutWiFiPortConfigurationService", request)
+	ret0, _ := ret[0].(wifiportconfiguration.WiFiPortConfigurationServiceResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutWiFiPortConfigurationService indicates an expected call of PutWiFiPortConfigurationService.
+func (mr *MockManagementMockRecorder) PutWiFiPortConfigurationService(request any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutWiFiPortConfigurationService", reflect.TypeOf((*MockManagement)(nil).PutWiFiPortConfigurationService), request)
 }
 
 // RequestAMTRedirectionServiceStateChange mocks base method.

--- a/internal/mocks/wsv1_mocks.go
+++ b/internal/mocks/wsv1_mocks.go
@@ -587,21 +587,6 @@ func (mr *MockFeatureMockRecorder) GetVersion(ctx, guid any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetVersion", reflect.TypeOf((*MockFeature)(nil).GetVersion), ctx, guid)
 }
 
-// GetWirelessProfiles mocks base method.
-func (m *MockFeature) GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWirelessProfiles", c, guid)
-	ret0, _ := ret[0].([]dto.WirelessProfileResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetWirelessProfiles indicates an expected call of GetWirelessProfiles.
-func (mr *MockFeatureMockRecorder) GetWirelessProfiles(c, guid any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockFeature)(nil).GetWirelessProfiles), c, guid)
-}
-
 // GetWiredNetworkSettings mocks base method.
 func (m *MockFeature) GetWiredNetworkSettings(c context.Context, guid string) (dto.WiredNetworkInfo, error) {
 	m.ctrl.T.Helper()
@@ -615,6 +600,36 @@ func (m *MockFeature) GetWiredNetworkSettings(c context.Context, guid string) (d
 func (mr *MockFeatureMockRecorder) GetWiredNetworkSettings(c, guid any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWiredNetworkSettings", reflect.TypeOf((*MockFeature)(nil).GetWiredNetworkSettings), c, guid)
+}
+
+// GetWirelessProfileSync mocks base method.
+func (m *MockFeature) GetWirelessProfileSync(c context.Context, guid string) (dto.WirelessProfileSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWirelessProfileSync", c, guid)
+	ret0, _ := ret[0].(dto.WirelessProfileSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWirelessProfileSync indicates an expected call of GetWirelessProfileSync.
+func (mr *MockFeatureMockRecorder) GetWirelessProfileSync(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfileSync", reflect.TypeOf((*MockFeature)(nil).GetWirelessProfileSync), c, guid)
+}
+
+// GetWirelessProfiles mocks base method.
+func (m *MockFeature) GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWirelessProfiles", c, guid)
+	ret0, _ := ret[0].([]dto.WirelessProfileResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetWirelessProfiles indicates an expected call of GetWirelessProfiles.
+func (mr *MockFeatureMockRecorder) GetWirelessProfiles(c, guid any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWirelessProfiles", reflect.TypeOf((*MockFeature)(nil).GetWirelessProfiles), c, guid)
 }
 
 // GetWirelessState mocks base method.
@@ -779,6 +794,21 @@ func (m *MockFeature) SetLinkPreference(c context.Context, guid string, req dto.
 func (mr *MockFeatureMockRecorder) SetLinkPreference(c, guid, req any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetLinkPreference", reflect.TypeOf((*MockFeature)(nil).SetLinkPreference), c, guid, req)
+}
+
+// SetWirelessProfileSync mocks base method.
+func (m *MockFeature) SetWirelessProfileSync(c context.Context, guid string, req dto.WirelessProfileSyncRequest) (dto.WirelessProfileSyncResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetWirelessProfileSync", c, guid, req)
+	ret0, _ := ret[0].(dto.WirelessProfileSyncResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetWirelessProfileSync indicates an expected call of SetWirelessProfileSync.
+func (mr *MockFeatureMockRecorder) SetWirelessProfileSync(c, guid, req any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetWirelessProfileSync", reflect.TypeOf((*MockFeature)(nil).SetWirelessProfileSync), c, guid, req)
 }
 
 // Update mocks base method.

--- a/internal/usecase/devices/interfaces.go
+++ b/internal/usecase/devices/interfaces.go
@@ -86,6 +86,8 @@ type (
 		PatchWiredNetworkSettings(c context.Context, guid string, req dto.WiredNetworkConfigRequest) error
 		RequestWirelessStateChange(c context.Context, guid string, requestedState wifi.RequestedState) (wifi.RequestedState, error)
 		GetWirelessState(c context.Context, guid string) (wifi.EnabledState, error)
+		GetWirelessProfileSync(c context.Context, guid string) (dto.WirelessProfileSyncResponse, error)
+		SetWirelessProfileSync(c context.Context, guid string, req dto.WirelessProfileSyncRequest) (dto.WirelessProfileSyncResponse, error)
 		GetWirelessProfiles(c context.Context, guid string) ([]dto.WirelessProfileResponse, error)
 		AddWirelessProfile(c context.Context, guid string, profile config.WirelessProfile) error
 		DeleteWirelessProfile(c context.Context, guid, profileName string) error

--- a/internal/usecase/devices/wifiprofilesync.go
+++ b/internal/usecase/devices/wifiprofilesync.go
@@ -1,0 +1,129 @@
+package devices
+
+import (
+	"context"
+	"errors"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/wifiportconfiguration"
+
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+)
+
+// ErrUEFIProfileSyncNotSupported is returned when a caller requests UEFI WiFi
+// profile sharing on a device whose power capabilities do not support it. The
+// HTTP layer maps this to 409 Conflict and the whole request is rejected (no
+// partial update).
+var ErrUEFIProfileSyncNotSupported = errors.New("UEFI WiFi profile sync is not supported on this device")
+
+func (uc *UseCase) GetWirelessProfileSync(c context.Context, guid string) (dto.WirelessProfileSyncResponse, error) {
+	device, err := uc.setupWirelessProfileManagement(c, guid)
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	if _, err := device.GetWiFiPorts(); err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	response, err := device.GetWiFiPortConfigurationService()
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	powerCapabilities, err := device.GetPowerCapabilities()
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	uefiSupported := powerCapabilities.UEFIWiFiCoExistenceAndProfileShare
+
+	return buildProfileSyncResponse(response, uefiSupported), nil
+}
+
+func (uc *UseCase) SetWirelessProfileSync(c context.Context, guid string, req dto.WirelessProfileSyncRequest) (dto.WirelessProfileSyncResponse, error) {
+	device, err := uc.setupWirelessProfileManagement(c, guid)
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	if _, err := device.GetWiFiPorts(); err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	current, err := device.GetWiFiPortConfigurationService()
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	powerCapabilities, err := device.GetPowerCapabilities()
+	if err != nil {
+		return dto.WirelessProfileSyncResponse{}, err
+	}
+
+	uefiSupported := powerCapabilities.UEFIWiFiCoExistenceAndProfileShare
+
+	// Reject the entire request (no partial update) when UEFI sync is explicitly
+	// requested on a device that does not support it.
+	if req.UEFIProfileSync != nil && *req.UEFIProfileSync && !uefiSupported {
+		return dto.WirelessProfileSyncResponse{}, ErrUEFIProfileSyncNotSupported
+	}
+
+	localSyncState := current.LocalProfileSynchronizationEnabled
+	if req.LocalProfileSync != nil {
+		localSyncState = wifiportconfiguration.LocalSyncDisabled
+		if *req.LocalProfileSync {
+			localSyncState = wifiportconfiguration.LocalUserProfileSynchronizationEnabled
+		}
+	}
+
+	uefiSyncState := current.UEFIWiFiProfileShareEnabled
+	if req.UEFIProfileSync != nil {
+		uefiSyncState = *req.UEFIProfileSync
+	}
+
+	if localSyncState != current.LocalProfileSynchronizationEnabled || uefiSyncState != current.UEFIWiFiProfileShareEnabled {
+		putRequest := buildWiFiPortConfigRequest(current, localSyncState, uefiSyncState)
+
+		updatedResponse, err := device.PutWiFiPortConfigurationService(putRequest)
+		if err != nil {
+			return dto.WirelessProfileSyncResponse{}, err
+		}
+
+		return buildProfileSyncResponse(updatedResponse, uefiSupported), nil
+	}
+
+	return buildProfileSyncResponse(current, uefiSupported), nil
+}
+
+func buildProfileSyncResponse(cfg wifiportconfiguration.WiFiPortConfigurationServiceResponse, uefiSupported bool) dto.WirelessProfileSyncResponse {
+	return dto.WirelessProfileSyncResponse{
+		LocalProfileSync:         isLocalProfileSyncEnabled(cfg.LocalProfileSynchronizationEnabled),
+		UEFIProfileSync:          cfg.UEFIWiFiProfileShareEnabled,
+		UEFIProfileSyncSupported: uefiSupported,
+	}
+}
+
+func buildWiFiPortConfigRequest(
+	current wifiportconfiguration.WiFiPortConfigurationServiceResponse,
+	localSyncState wifiportconfiguration.LocalProfileSynchronizationEnabled,
+	uefiWiFiSyncState bool,
+) wifiportconfiguration.WiFiPortConfigurationServiceRequest {
+	return wifiportconfiguration.WiFiPortConfigurationServiceRequest{
+		RequestedState:                     current.RequestedState,
+		EnabledState:                       current.EnabledState,
+		HealthState:                        current.HealthState,
+		ElementName:                        current.ElementName,
+		SystemCreationClassName:            current.SystemCreationClassName,
+		SystemName:                         current.SystemName,
+		CreationClassName:                  current.CreationClassName,
+		Name:                               current.Name,
+		LocalProfileSynchronizationEnabled: localSyncState,
+		LastConnectedSsidUnderMeControl:    current.LastConnectedSsidUnderMeControl,
+		NoHostCsmeSoftwarePolicy:           current.NoHostCsmeSoftwarePolicy,
+		UEFIWiFiProfileShareEnabled:        uefiWiFiSyncState,
+	}
+}
+
+func isLocalProfileSyncEnabled(state wifiportconfiguration.LocalProfileSynchronizationEnabled) bool {
+	return state == wifiportconfiguration.LocalUserProfileSynchronizationEnabled
+}

--- a/internal/usecase/devices/wifiprofilesync_test.go
+++ b/internal/usecase/devices/wifiprofilesync_test.go
@@ -1,0 +1,333 @@
+package devices_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/boot"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/amt/wifiportconfiguration"
+	"github.com/device-management-toolkit/go-wsman-messages/v2/pkg/wsman/cim/wifi"
+
+	"github.com/device-management-toolkit/console/internal/entity"
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	"github.com/device-management-toolkit/console/internal/mocks"
+	"github.com/device-management-toolkit/console/internal/usecase/devices"
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+var errWiFiProfileSync = errors.New("wifi profile sync failure")
+
+func testBoolPtr(b bool) *bool { return &b }
+
+func initWiFiProfileSyncTest(t *testing.T) (*devices.UseCase, *mocks.MockWSMAN, *mocks.MockManagement, *mocks.MockDeviceManagementRepository) {
+	t.Helper()
+
+	mockCtl := gomock.NewController(t)
+
+	repo := mocks.NewMockDeviceManagementRepository(mockCtl)
+	wsmanMock := mocks.NewMockWSMAN(mockCtl)
+	wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+	management := mocks.NewMockManagement(mockCtl)
+	log := logger.New("error")
+	u := devices.New(repo, wsmanMock, mocks.NewMockRedirection(mockCtl), log, mocks.MockCrypto{})
+
+	return u, wsmanMock, management, repo
+}
+
+func TestWiFiProfileSync(t *testing.T) {
+	t.Parallel()
+
+	const guid = "device-guid-123"
+
+	tests := []struct {
+		name      string
+		setupMock func(t *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement)
+		invoke    func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error)
+		want      dto.WirelessProfileSyncResponse
+		wantErr   bool
+		wantErrIs error
+	}{
+		{
+			name: "get wireless profile sync - enabled and supported",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalUserProfileSynchronizationEnabled,
+					UEFIWiFiProfileShareEnabled:        true,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: true, UEFIProfileSync: true, UEFIProfileSyncSupported: true},
+		},
+		{
+			name: "get wireless profile sync - disabled and unsupported",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+					UEFIWiFiProfileShareEnabled:        false,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: false}, nil)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: false, UEFIProfileSync: false, UEFIProfileSyncSupported: false},
+		},
+		{
+			name: "get wireless profile sync - setup error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				repo.EXPECT().GetByID(context.Background(), guid, "").Return(nil, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			wantErr: true,
+		},
+		{
+			name: "get wireless profile sync - get wifi ports error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return(nil, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			wantErr: true,
+		},
+		{
+			name: "get wireless profile sync - get config error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{}, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			wantErr: true,
+		},
+		{
+			name: "get wireless profile sync - power capabilities error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{}, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.GetWirelessProfileSync(context.Background(), guid)
+			},
+			wantErr: true,
+		},
+		{
+			name: "set wireless profile sync - enable local (PUT issued)",
+			setupMock: func(t *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				t.Helper()
+
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+					UEFIWiFiProfileShareEnabled:        false,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+				management.EXPECT().PutWiFiPortConfigurationService(gomock.Any()).DoAndReturn(func(req wifiportconfiguration.WiFiPortConfigurationServiceRequest) (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error) {
+					assert.Equal(t, wifiportconfiguration.LocalUserProfileSynchronizationEnabled, req.LocalProfileSynchronizationEnabled)
+					assert.False(t, req.UEFIWiFiProfileShareEnabled)
+
+					return wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+						LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalUserProfileSynchronizationEnabled,
+						UEFIWiFiProfileShareEnabled:        false,
+					}, nil
+				})
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: true, UEFIProfileSync: false, UEFIProfileSyncSupported: true},
+		},
+		{
+			name: "set wireless profile sync - enable uefi supported (PUT issued)",
+			setupMock: func(t *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				t.Helper()
+
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+					UEFIWiFiProfileShareEnabled:        false,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+				management.EXPECT().PutWiFiPortConfigurationService(gomock.Any()).DoAndReturn(func(req wifiportconfiguration.WiFiPortConfigurationServiceRequest) (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error) {
+					assert.True(t, req.UEFIWiFiProfileShareEnabled)
+
+					return wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+						LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+						UEFIWiFiProfileShareEnabled:        true,
+					}, nil
+				})
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{UEFIProfileSync: testBoolPtr(true)})
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: false, UEFIProfileSync: true, UEFIProfileSyncSupported: true},
+		},
+		{
+			name: "set wireless profile sync - enable uefi unsupported rejected (no PUT)",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+					UEFIWiFiProfileShareEnabled:        false,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: false}, nil)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true), UEFIProfileSync: testBoolPtr(true)})
+			},
+			wantErr:   true,
+			wantErrIs: devices.ErrUEFIProfileSyncNotSupported,
+		},
+		{
+			name: "set wireless profile sync - no change needed",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalUserProfileSynchronizationEnabled,
+					UEFIWiFiProfileShareEnabled:        false,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true), UEFIProfileSync: testBoolPtr(false)})
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: true, UEFIProfileSync: false, UEFIProfileSyncSupported: true},
+		},
+		{
+			name: "set wireless profile sync - empty request returns current state",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalUserProfileSynchronizationEnabled,
+					UEFIWiFiProfileShareEnabled:        true,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{})
+			},
+			want: dto.WirelessProfileSyncResponse{LocalProfileSync: true, UEFIProfileSync: true, UEFIProfileSyncSupported: true},
+		},
+		{
+			name: "set wireless profile sync - setup error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				repo.EXPECT().GetByID(context.Background(), guid, "").Return(nil, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			wantErr: true,
+		},
+		{
+			name: "set wireless profile sync - get wifi ports error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return(nil, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			wantErr: true,
+		},
+		{
+			name: "set wireless profile sync - get config error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{}, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			wantErr: true,
+		},
+		{
+			name: "set wireless profile sync - power capabilities error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{}, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			wantErr: true,
+		},
+		{
+			name: "set wireless profile sync - put config error",
+			setupMock: func(_ *testing.T, repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				expectSetupSuccess(repo, wsmanMock, management)
+				management.EXPECT().GetWiFiPorts().Return([]wifi.WiFiPort{{}}, nil)
+				management.EXPECT().GetWiFiPortConfigurationService().Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{
+					LocalProfileSynchronizationEnabled: wifiportconfiguration.LocalSyncDisabled,
+				}, nil)
+				management.EXPECT().GetPowerCapabilities().Return(boot.BootCapabilitiesResponse{UEFIWiFiCoExistenceAndProfileShare: true}, nil)
+				management.EXPECT().PutWiFiPortConfigurationService(gomock.Any()).Return(wifiportconfiguration.WiFiPortConfigurationServiceResponse{}, errWiFiProfileSync)
+			},
+			invoke: func(useCase *devices.UseCase) (dto.WirelessProfileSyncResponse, error) {
+				return useCase.SetWirelessProfileSync(context.Background(), guid, dto.WirelessProfileSyncRequest{LocalProfileSync: testBoolPtr(true)})
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			useCase, wsmanMock, management, repo := initWiFiProfileSyncTest(t)
+			tc.setupMock(t, repo, wsmanMock, management)
+
+			got, err := tc.invoke(useCase)
+
+			if tc.wantErr {
+				require.Error(t, err)
+
+				if tc.wantErrIs != nil {
+					require.ErrorIs(t, err, tc.wantErrIs)
+				}
+
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func expectSetupSuccess(repo *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+	const guid = "device-guid-123"
+
+	device := &entity.Device{GUID: guid}
+
+	repo.EXPECT().GetByID(context.Background(), guid, "").Return(device, nil)
+	wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil)
+}

--- a/internal/usecase/devices/wsman/interfaces.go
+++ b/internal/usecase/devices/wsman/interfaces.go
@@ -67,6 +67,8 @@ type Management interface {
 	GetEthernetPortSettings() ([]ethernetport.SettingsResponse, error)
 	PutEthernetPortSettings(ethernetPortSettings ethernetport.SettingsRequest, instanceID string) (ethernetport.Response, error)
 	GetWiFiSettings() ([]wifi.WiFiEndpointSettingsResponse, error)
+	GetWiFiPortConfigurationService() (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error)
+	PutWiFiPortConfigurationService(request wifiportconfiguration.WiFiPortConfigurationServiceRequest) (wifiportconfiguration.WiFiPortConfigurationServiceResponse, error)
 	GetCIMIEEE8021xSettings() (cimIEEE8021x.Response, error)
 	DeleteWiFiSetting(instanceID string) error
 	AddWiFiSettings(wifiEndpointSettings wifi.WiFiEndpointSettingsRequest, ieee8021xSettings models.IEEE8021xSettings, wifiEndpoint, clientCredential, caCredential string) (wifiportconfiguration.Response, error)


### PR DESCRIPTION
Add GET/POST endpoints to read and toggle AMT wireless profile synchronization on a device:

  GET/POST /api/v1/amt/networkSettings/wireless/profileSync/{guid}

The use case drives the WiFiPortConfigurationService over WSMAN, reading current state and only issuing a PUT when the requested value differs. UEFI sync is gated on the device's
UEFIWiFiCoExistenceAndProfileShare power capability so unsupported hardware can't be enabled.

Wires the new methods through the devices.Feature and ws/v1.Feature interfaces, regenerates mocks, declares the routes in the Fuego OpenAPI adapter, and adds matching entries to the MPS Postman collection. Covered by handler and use-case unit tests.

Resolves #835

NOTES:
- Developer guide: [Wireless Profile Sync Settings Management Architecture](https://github.com/device-management-toolkit/console/wiki/Wireless-Profile-Sync-Settings-Management-Architecture)

# On-target Functional Test

Functional Postman/Newman corpus for the WiFi Profile Sync feature in Console. The
objective is to exercise the **behavior** of the API (every logic branch in the use
case), not merely the request contract.

## Files

| File | Purpose |
| --- | --- |
| [wireless_profile_sync.postman_collection.json](https://github.com/user-attachments/files/28997225/wireless_profile_sync.postman_collection.json) | The requests + assertions |
| [wireless_profile_sync.postman_environment.json](https://github.com/user-attachments/files/28997238/wireless_profile_sync.postman_environment.json) | Host, credentials, device GUID, capture vars |

## Endpoints under test

| Method | Path | Behavior |
| --- | --- | --- |
| GET  | `/api/v1/amt/networkSettings/wireless/profileSync/{guid}` | Read profile sync settings |
| POST | `/api/v1/amt/networkSettings/wireless/profileSync/{guid}` | Update profile sync settings |

## Pre-requisites

- console app is running
- 2 devices provisioned and guid captured
  - device1: with wifi adapter
  - device2: without wifi adapter
- newman installed


## How to run

```bash
# Modify the value of following keys in the environment file
# - protocol
# - host
# - consoleUser
# - consolePass
# - deviceId
# - noWifiDeviceId

# Execute newman test
newman run console_wifi_profile_sync.postman_collection.json \
  -e console_wifi_profile_sync.postman_environment.json
```

## Test cases

| # | Request | Body | Asserts |
| --- | --- | --- | --- |
| 10 | POST profile sync, `localProfileSync` as string | `{"localProfileSync":"yes"}` | 400 |
| 11 | POST profile sync, `uefiProfileSync` as number | `{"uefiProfileSync":1}` | 400 |
| 20 | GET profile sync on no-WiFi device | — | 404 |
| 21 | POST profile sync on no-WiFi device (valid body) | `{"localProfileSync":true}` | 404 |
| 00 | Get current profile sync | — | 200, well-formed object; captures `uefiProfileSyncSupported` → `uefiSupported` |
| 01 | Disable local profile sync — POST | `{"localProfileSync":false}` | 200, `localProfileSync=false` |
| 01 | Verify local sync disabled (GET after settle) | — | 200, read-back `localProfileSync=false` |
| 02 | Enable local profile sync — POST | `{"localProfileSync":true}` | 200, `localProfileSync=true` |
| 02 | Verify local sync enabled (GET after settle) | — | 200, read-back `localProfileSync=true` |
| 03 | Enable UEFI profile sync (capability-aware) — POST | `{"uefiProfileSync":true}` | 200 + `uefiProfileSync=true` **if** `uefiSupported`, else **409** |
| 04 | Disable UEFI profile sync (always allowed) — POST | `{"uefiProfileSync":false}` | 200, `uefiProfileSync=false` |
| 05 | No-op update (omit both fields) — POST | `{}` | 200, values unchanged (local on, UEFI off) |
| 05b | Null field treated as omitted — POST | `{"localProfileSync":null,"uefiProfileSync":null}` | 200, values unchanged (parity: MPS == Console) |
| 06 | Verify final state (GET after settle) | — | 200, `localProfileSync=true`, `uefiProfileSync=false` |
