### PR TITLE
feat(redfish): implement redfish SOL user consent actions

### DIFF
--- a/redfish/internal/controller/http/v1/handler/routes_test.go
+++ b/redfish/internal/controller/http/v1/handler/routes_test.go
@@ -132,6 +132,30 @@ func (r *TestComputerSystemRepository) CancelKVMConsent(_ context.Context, syste
 	return usecase.ErrSystemNotFound
 }
 
+func (r *TestComputerSystemRepository) RequestSolConsent(_ context.Context, systemID string) error {
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
+func (r *TestComputerSystemRepository) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
+func (r *TestComputerSystemRepository) CancelSolConsent(_ context.Context, systemID string) error {
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
 // createTestSystemData creates a test system for the repository
 func createTestSystemData(systemID, name, manufacturer, model, serialNumber string) *redfishv1.ComputerSystem {
 	return &redfishv1.ComputerSystem{

--- a/redfish/internal/controller/http/v1/handler/systems_actions.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions.go
@@ -172,7 +172,6 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 }
 
 // PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent handles canceling SOL consent for a computer system.
-// This is a stub implementation.
 //
 //nolint:revive // Method name is generated from OpenAPI spec and cannot be changed
 func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(c *gin.Context, computerSystemID string) {
@@ -182,7 +181,43 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 		return
 	}
 
-	MethodNotAllowedError(c)
+	var req generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsentJSONRequestBody
+
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		MalformedJSONError(c)
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.CancelSolConsent(c.Request.Context(), computerSystemID); err != nil {
+		var consentErr *usecase.ConsentFailedError
+
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		case errors.As(err, &consentErr):
+			BadRequestError(c, consentErr.Error())
+		case isAMTBadRequestError(err):
+			BadRequestError(c, err.Error())
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	sendActionSuccessResponse(c)
 }
 
 // PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemGenerateRedirectionToken handles generating a redirection token for a computer system.
@@ -271,7 +306,6 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 }
 
 // PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent handles requesting SOL consent for a computer system.
-// This is a stub implementation.
 //
 //nolint:revive // Method name is generated from OpenAPI spec and cannot be changed
 func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(c *gin.Context, computerSystemID string) {
@@ -281,7 +315,45 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 		return
 	}
 
-	MethodNotAllowedError(c)
+	var req generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsentJSONRequestBody
+
+	if err := c.ShouldBindJSON(&req); err != nil && !errors.Is(err, io.EOF) {
+		MalformedJSONError(c)
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.RequestSolConsent(c.Request.Context(), computerSystemID); err != nil {
+		var consentErr *usecase.ConsentFailedError
+
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		case errors.Is(err, usecase.ErrSOLConsentNotRequiredInACM):
+			BadRequestError(c, err.Error())
+		case errors.As(err, &consentErr):
+			BadRequestError(c, consentErr.Error())
+		case isAMTBadRequestError(err):
+			BadRequestError(c, err.Error())
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	sendActionSuccessResponse(c)
 }
 
 // PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitKVMConsentCode handles submitting a KVM consent code for a computer system.
@@ -347,7 +419,6 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 }
 
 // PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode handles submitting a SOL consent code for a computer system.
-// This is a stub implementation.
 //
 //nolint:revive // Method name is generated from OpenAPI spec and cannot be changed
 func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(c *gin.Context, computerSystemID string) {
@@ -357,7 +428,56 @@ func (s *RedfishServer) PostRedfishV1SystemsComputerSystemIdActionsOemIntelCompu
 		return
 	}
 
-	MethodNotAllowedError(c)
+	var req generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCodeJSONRequestBody
+
+	if err := c.ShouldBindJSON(&req); err != nil {
+		MalformedJSONError(c)
+
+		return
+	}
+
+	consentCode := strings.TrimSpace(req.ConsentCode)
+	if consentCode == "" {
+		PropertyMissingError(c, "ConsentCode")
+
+		return
+	}
+
+	if !sixDigitConsentCodeRe.MatchString(consentCode) {
+		BadRequestError(c, "Invalid ConsentCode: must be a six-digit numeric value")
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.EnsureSystemExists(c.Request.Context(), computerSystemID); err != nil {
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	if err := s.ComputerSystemUC.SubmitSolConsentCode(c.Request.Context(), computerSystemID, consentCode); err != nil {
+		var consentErr *usecase.ConsentFailedError
+
+		switch {
+		case errors.Is(err, usecase.ErrSystemNotFound):
+			NotFoundError(c, "System", computerSystemID)
+		case errors.As(err, &consentErr):
+			BadRequestError(c, consentErr.Error())
+		case isAMTBadRequestError(err):
+			BadRequestError(c, err.Error())
+		default:
+			InternalServerError(c, err)
+		}
+
+		return
+	}
+
+	sendActionSuccessResponse(c)
 }
 
 func sendActionSuccessResponse(c *gin.Context) {

--- a/redfish/internal/controller/http/v1/handler/systems_actions_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions_test.go
@@ -59,6 +59,9 @@ const (
 	requestKVMConsentEndpoint   = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.RequestKVMConsent"
 	submitKVMConsentEndpoint    = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.SubmitKVMConsentCode"
 	cancelKVMConsentEndpoint    = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.CancelKVMConsent"
+	requestSolConsentEndpoint   = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.RequestSolConsent"
+	submitSolConsentEndpoint    = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode"
+	cancelSolConsentEndpoint    = "/redfish/v1/Systems/550e8400-e29b-41d4-a716-446655440001/Actions/Oem/IntelComputerSystem.CancelSolConsent"
 	taskServiceEndpoint         = "/redfish/v1/TaskService/Tasks/"
 	taskODataContext            = "/redfish/v1/$metadata#Task.Task"
 	taskODataType               = "#Task.v1_6_0.Task"
@@ -106,6 +109,21 @@ func setupSystemActionsTestRouter(server *RedfishServer) *gin.Engine {
 			computerSystemID := c.Param("computerSystemId")
 			server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelKVMConsent(c, computerSystemID)
 		})
+	router.POST("/redfish/v1/Systems/:computerSystemId/Actions/Oem/IntelComputerSystem.RequestSolConsent",
+		func(c *gin.Context) {
+			computerSystemID := c.Param("computerSystemId")
+			server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(c, computerSystemID)
+		})
+	router.POST("/redfish/v1/Systems/:computerSystemId/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode",
+		func(c *gin.Context) {
+			computerSystemID := c.Param("computerSystemId")
+			server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(c, computerSystemID)
+		})
+	router.POST("/redfish/v1/Systems/:computerSystemId/Actions/Oem/IntelComputerSystem.CancelSolConsent",
+		func(c *gin.Context) {
+			computerSystemID := c.Param("computerSystemId")
+			server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(c, computerSystemID)
+		})
 
 	return router
 }
@@ -137,6 +155,15 @@ func createEmptyActionRequest() []byte {
 
 func createSubmitKVMConsentCodeRequest(code string) []byte {
 	req := generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitKVMConsentCodeJSONRequestBody{
+		ConsentCode: code,
+	}
+	body, _ := json.Marshal(req)
+
+	return body
+}
+
+func createSubmitSolConsentCodeRequest(code string) []byte {
+	req := generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCodeJSONRequestBody{
 		ConsentCode: code,
 	}
 	body, _ := json.Marshal(req)
@@ -882,17 +909,14 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancel
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
 	server := setupSystemActionsTestServer(repo)
+	router := setupSystemActionsTestRouter(server)
 
-	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+testSystemID+"/Actions/Oem/IntelComputerSystem.CancelSolConsent", http.NoBody)
-	w := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(w)
-	ctx.Request = req
-	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+	w := executeResetRequest(router, cancelSolConsentEndpoint, createEmptyActionRequest())
 
-	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
-
-	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_InvalidSystemID(t *testing.T) {
@@ -973,17 +997,14 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemReques
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
 	server := setupSystemActionsTestServer(repo)
+	router := setupSystemActionsTestRouter(server)
 
-	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+testSystemID+"/Actions/Oem/IntelComputerSystem.RequestSolConsent", http.NoBody)
-	w := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(w)
-	ctx.Request = req
-	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+	w := executeResetRequest(router, requestSolConsentEndpoint, createEmptyActionRequest())
 
-	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
-
-	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_InvalidSystemID(t *testing.T) {
@@ -1007,17 +1028,14 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmit
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test"})
+
 	server := setupSystemActionsTestServer(repo)
+	router := setupSystemActionsTestRouter(server)
 
-	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+testSystemID+"/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode", http.NoBody)
-	w := httptest.NewRecorder()
-	ctx, _ := gin.CreateTestContext(w)
-	ctx.Request = req
-	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+	w := executeResetRequest(router, submitSolConsentEndpoint, createSubmitSolConsentCodeRequest("123456"))
 
-	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
-
-	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 }
 
 func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_InvalidSystemID(t *testing.T) {

--- a/redfish/internal/controller/http/v1/handler/systems_actions_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions_test.go
@@ -905,7 +905,7 @@ func TestSendActionSuccessResponseWithLookup_Success(t *testing.T) {
 
 // Stub implementation tests for SOL actions
 
-func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_Stub(t *testing.T) {
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_WithRouter(t *testing.T) {
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
@@ -993,7 +993,7 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancel
 	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }
 
-func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_Stub(t *testing.T) {
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_WithRouter(t *testing.T) {
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
@@ -1024,7 +1024,7 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemReques
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
-func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_Stub(t *testing.T) {
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_WithRouter(t *testing.T) {
 	t.Parallel()
 
 	repo := NewTestSystemsComputerSystemRepository()
@@ -1053,4 +1053,456 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmit
 	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, "<script>")
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// Additional SOL Consent Tests for Coverage
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_SystemNotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	server := setupSystemActionsTestServer(repo)
+
+	nonExistentID := "550e8400-e29b-41d4-a716-446655440999"
+
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+nonExistentID+"/Actions/Oem/IntelComputerSystem.RequestSolConsent", http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: nonExistentID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, nonExistentID)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	server := setupSystemActionsTestServer(repo)
+
+	malformedBody := bytes.NewReader([]byte("{invalid json"))
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, malformedBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_ConsentFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		requestSolConsentErr: &usecase.ConsentFailedError{
+			Operation:   "RequestSolConsent",
+			ReturnValue: 2, // Invalid state error
+		},
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_ACMNotRequired(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		requestSolConsentErr: usecase.ErrSOLConsentNotRequiredInACM,
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_AMTBadRequest(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		requestSolConsentErr: errors.New("400 Bad Request"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent_InternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		requestSolConsentErr: errors.New("internal server error"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, requestSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemRequestSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{"ConsentCode": "123456"}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_SystemNotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	server := setupSystemActionsTestServer(repo)
+
+	nonExistentID := "550e8400-e29b-41d4-a716-446655440999"
+	body := []byte(`{"ConsentCode": "123456"}`)
+
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+nonExistentID+"/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: nonExistentID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, nonExistentID)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_InvalidConsentCode(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		submitSolConsentCodeErr: usecase.ErrInvalidConsentCode,
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{"ConsentCode": "12345"}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_MissingConsentCode(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_MalformedJSON(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	malformedBody := bytes.NewReader([]byte("{invalid json"))
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, malformedBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_ConsentFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		submitSolConsentCodeErr: &usecase.ConsentFailedError{
+			Operation:   "SubmitSolConsentCode",
+			ReturnValue: 2066, // Consent code invalid
+		},
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{"ConsentCode": "123456"}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_AMTBadRequest(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		submitSolConsentCodeErr: errors.New("400 Bad Request from AMT"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{"ConsentCode": "123456"}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_InternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		submitSolConsentCodeErr: errors.New("internal server error"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	body := []byte(`{"ConsentCode": "123456"}`)
+
+	req := httptest.NewRequest(http.MethodPost, submitSolConsentEndpoint, bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_Success(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, cancelSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_EmptyBody(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, cancelSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_SystemNotFound(t *testing.T) {
+	t.Parallel()
+
+	repo := NewTestSystemsComputerSystemRepository()
+	server := setupSystemActionsTestServer(repo)
+
+	nonExistentID := "550e8400-e29b-41d4-a716-446655440999"
+
+	req := httptest.NewRequest(http.MethodPost, "/redfish/v1/Systems/"+nonExistentID+"/Actions/Oem/IntelComputerSystem.CancelSolConsent", http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: nonExistentID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, nonExistentID)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_ConsentFailure(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		cancelSolConsentErr: &usecase.ConsentFailedError{
+			Operation:   "CancelSolConsent",
+			ReturnValue: 2, // Invalid state error
+		},
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, cancelSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_AMTBadRequest(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		cancelSolConsentErr: errors.New("400 Bad Request"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, cancelSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent_InternalError(t *testing.T) {
+	t.Parallel()
+
+	repo := &TestSystemsComputerSystemRepository{
+		systems: map[string]*redfishv1.ComputerSystem{
+			testSystemID: {},
+		},
+		cancelSolConsentErr: errors.New("internal server error"),
+	}
+	server := setupSystemActionsTestServer(repo)
+
+	req := httptest.NewRequest(http.MethodPost, cancelSolConsentEndpoint, http.NoBody)
+	w := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(w)
+	ctx.Request = req
+	ctx.Params = gin.Params{{Key: "computerSystemId", Value: testSystemID}}
+
+	server.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemCancelSolConsent(ctx, testSystemID)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
 }

--- a/redfish/internal/controller/http/v1/handler/systems_actions_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_actions_test.go
@@ -1247,12 +1247,9 @@ func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmit
 func TestPostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitSolConsentCode_InvalidConsentCode(t *testing.T) {
 	t.Parallel()
 
-	repo := &TestSystemsComputerSystemRepository{
-		systems: map[string]*redfishv1.ComputerSystem{
-			testSystemID: {},
-		},
-		submitSolConsentCodeErr: usecase.ErrInvalidConsentCode,
-	}
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{})
+
 	server := setupSystemActionsTestServer(repo)
 
 	body := []byte(`{"ConsentCode": "12345"}`)

--- a/redfish/internal/controller/http/v1/handler/systems_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_test.go
@@ -213,6 +213,42 @@ func (r *TestSystemsComputerSystemRepository) CancelKVMConsent(_ context.Context
 	return usecase.ErrSystemNotFound
 }
 
+func (r *TestSystemsComputerSystemRepository) RequestSolConsent(_ context.Context, systemID string) error {
+	if err, exists := r.errorOnGetByID[systemID]; exists {
+		return err
+	}
+
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
+func (r *TestSystemsComputerSystemRepository) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+	if err, exists := r.errorOnGetByID[systemID]; exists {
+		return err
+	}
+
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
+func (r *TestSystemsComputerSystemRepository) CancelSolConsent(_ context.Context, systemID string) error {
+	if err, exists := r.errorOnGetByID[systemID]; exists {
+		return err
+	}
+
+	if _, exists := r.systems[systemID]; exists {
+		return nil
+	}
+
+	return usecase.ErrSystemNotFound
+}
+
 // TestCase represents a generic test case structure
 type SystemsTestCase[T any] struct {
 	name           string

--- a/redfish/internal/controller/http/v1/handler/systems_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_test.go
@@ -51,12 +51,15 @@ var (
 
 // TestSystemsComputerSystemRepository is a test implementation for systems tests
 type TestSystemsComputerSystemRepository struct {
-	systems           map[string]*redfishv1.ComputerSystem
-	errorOnGetAll     bool
-	errorOnGetByID    map[string]error
-	errorOnUpdateBoot map[string]error
-	errorOnUpdateKVM  map[string]error
-	errorOnUpdateSOL  map[string]error
+	systems                 map[string]*redfishv1.ComputerSystem
+	errorOnGetAll           bool
+	errorOnGetByID          map[string]error
+	errorOnUpdateBoot       map[string]error
+	errorOnUpdateKVM        map[string]error
+	errorOnUpdateSOL        map[string]error
+	requestSolConsentErr    error
+	submitSolConsentCodeErr error
+	cancelSolConsentErr     error
 }
 
 func NewTestSystemsComputerSystemRepository() *TestSystemsComputerSystemRepository {
@@ -214,6 +217,10 @@ func (r *TestSystemsComputerSystemRepository) CancelKVMConsent(_ context.Context
 }
 
 func (r *TestSystemsComputerSystemRepository) RequestSolConsent(_ context.Context, systemID string) error {
+	if r.requestSolConsentErr != nil {
+		return r.requestSolConsentErr
+	}
+
 	if err, exists := r.errorOnGetByID[systemID]; exists {
 		return err
 	}
@@ -226,6 +233,10 @@ func (r *TestSystemsComputerSystemRepository) RequestSolConsent(_ context.Contex
 }
 
 func (r *TestSystemsComputerSystemRepository) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+	if r.submitSolConsentCodeErr != nil {
+		return r.submitSolConsentCodeErr
+	}
+
 	if err, exists := r.errorOnGetByID[systemID]; exists {
 		return err
 	}
@@ -238,6 +249,10 @@ func (r *TestSystemsComputerSystemRepository) SubmitSolConsentCode(_ context.Con
 }
 
 func (r *TestSystemsComputerSystemRepository) CancelSolConsent(_ context.Context, systemID string) error {
+	if r.cancelSolConsentErr != nil {
+		return r.cancelSolConsentErr
+	}
+
 	if err, exists := r.errorOnGetByID[systemID]; exists {
 		return err
 	}

--- a/redfish/internal/mocks/mock_repo.go
+++ b/redfish/internal/mocks/mock_repo.go
@@ -509,3 +509,30 @@ func isSixDigitConsentCode(code string) bool {
 
 	return true
 }
+
+// RequestSolConsent starts a mock SOL consent flow for an existing system.
+func (r *MockComputerSystemRepo) RequestSolConsent(_ context.Context, systemID string) error {
+	if _, exists := r.systems[systemID]; !exists {
+		return usecase.ErrSystemNotFound
+	}
+
+	return nil
+}
+
+// SubmitSolConsentCode accepts a mock six-digit consent code for SOL for an existing system.
+func (r *MockComputerSystemRepo) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+	if _, exists := r.systems[systemID]; !exists {
+		return usecase.ErrSystemNotFound
+	}
+
+	return nil
+}
+
+// CancelSolConsent cancels a mock SOL consent flow for an existing system.
+func (r *MockComputerSystemRepo) CancelSolConsent(_ context.Context, systemID string) error {
+	if _, exists := r.systems[systemID]; !exists {
+		return usecase.ErrSystemNotFound
+	}
+
+	return nil
+}

--- a/redfish/internal/mocks/mock_repo.go
+++ b/redfish/internal/mocks/mock_repo.go
@@ -570,7 +570,7 @@ func (r *MockComputerSystemRepo) SubmitSolConsentCode(_ context.Context, systemI
 }
 
 // CancelSolConsent cancels a mock SOL consent flow for an existing system,
-// resetting the consent state back to "Required".
+// resetting the opt-in state back to "NotStarted".
 func (r *MockComputerSystemRepo) CancelSolConsent(_ context.Context, systemID string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound

--- a/redfish/internal/mocks/mock_repo.go
+++ b/redfish/internal/mocks/mock_repo.go
@@ -84,7 +84,8 @@ const (
 	mockConsentCodeDenied  = "000000"
 	mockConsentCodeTimeout = "111111"
 
-	mockConsentOperationSubmit = "SubmitKVMConsentCode"
+	mockConsentOperationSubmit    = "SubmitKVMConsentCode"
+	mockConsentOperationSolSubmit = "SubmitSolConsentCode"
 
 	// Consent ReturnValues mirror the values used by the real WSMAN repository.
 	mockConsentReturnInvalidState = 2
@@ -510,29 +511,72 @@ func isSixDigitConsentCode(code string) bool {
 	return true
 }
 
-// RequestSolConsent starts a mock SOL consent flow for an existing system.
+// RequestSolConsent starts a mock SOL consent flow for an existing system,
+// transitioning the consent state to "Requested".
 func (r *MockComputerSystemRepo) RequestSolConsent(_ context.Context, systemID string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
+	state := r.kvmStateFor(systemID)
+	if strings.EqualFold(strings.TrimSpace(state.controlMode), mockControlModeACM) {
+		return usecase.ErrSOLConsentNotRequiredInACM
+	}
+
+	state.optInState = mockOptInRequested
+
 	return nil
 }
 
-// SubmitSolConsentCode accepts a mock six-digit consent code for SOL for an existing system.
-func (r *MockComputerSystemRepo) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+// SubmitSolConsentCode accepts a mock six-digit consent code for SOL for an existing
+// system and transitions the consent state based on the code submitted.
+func (r *MockComputerSystemRepo) SubmitSolConsentCode(_ context.Context, systemID, code string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
-	return nil
+	if !isSixDigitConsentCode(code) {
+		return usecase.ErrInvalidConsentCode
+	}
+
+	state := r.kvmStateFor(systemID)
+
+	// A consent code can only be submitted while a prompt is active.
+	if state.optInState != mockOptInRequested && state.optInState != mockOptInDisplayed {
+		return &usecase.ConsentFailedError{Operation: mockConsentOperationSolSubmit, ReturnValue: mockConsentReturnInvalidState}
+	}
+
+	if code == mockConsentCodeGranted {
+		state.optInState = mockOptInReceived
+
+		return nil
+	}
+
+	// Demo trigger codes drive the denied/timeout outcomes; any other code is
+	// treated as a security failure.
+	if code == mockConsentCodeDenied {
+		state.optInState = mockOptInDenied
+
+		return nil
+	}
+
+	if code == mockConsentCodeTimeout {
+		state.optInState = mockOptInTimeout
+
+		return nil
+	}
+
+	return &usecase.ConsentFailedError{Operation: mockConsentOperationSolSubmit, ReturnValue: mockConsentReturnCodeInvalid}
 }
 
-// CancelSolConsent cancels a mock SOL consent flow for an existing system.
+// CancelSolConsent cancels a mock SOL consent flow for an existing system,
+// resetting the consent state back to "Required".
 func (r *MockComputerSystemRepo) CancelSolConsent(_ context.Context, systemID string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
+
+	r.kvmStateFor(systemID).optInState = mockOptInNotStarted
 
 	return nil
 }

--- a/redfish/internal/usecase/computer_system.go
+++ b/redfish/internal/usecase/computer_system.go
@@ -583,6 +583,21 @@ func (uc *ComputerSystemUseCase) CancelKVMConsent(ctx context.Context, systemID 
 	return uc.Repo.CancelKVMConsent(ctx, systemID)
 }
 
+// RequestSolConsent triggers a user consent request for SOL on the target system.
+func (uc *ComputerSystemUseCase) RequestSolConsent(ctx context.Context, systemID string) error {
+	return uc.Repo.RequestSolConsent(ctx, systemID)
+}
+
+// SubmitSolConsentCode submits the user-provided SOL consent code.
+func (uc *ComputerSystemUseCase) SubmitSolConsentCode(ctx context.Context, systemID, consentCode string) error {
+	return uc.Repo.SubmitSolConsentCode(ctx, systemID, consentCode)
+}
+
+// CancelSolConsent cancels a pending SOL user consent request on the target system.
+func (uc *ComputerSystemUseCase) CancelSolConsent(ctx context.Context, systemID string) error {
+	return uc.Repo.CancelSolConsent(ctx, systemID)
+}
+
 // GenerateRedirectionToken validates that the target system exists and returns a short-lived redirection token.
 func (uc *ComputerSystemUseCase) GenerateRedirectionToken(ctx context.Context, systemID string) (*generated.ComputerSystemOemIntelAmtGenerateRedirectionTokenResponse, error) {
 	if err := uc.EnsureSystemExists(ctx, systemID); err != nil {
@@ -831,6 +846,12 @@ func (uc *ComputerSystemUseCase) createActionsStruct(systemID string) *generated
 	submitConsentCodeTitle := "Submit KVM Consent Code"
 	cancelConsentTarget := fmt.Sprintf("/redfish/v1/Systems/%s/Actions/Oem/IntelComputerSystem.CancelKVMConsent", systemID)
 	cancelConsentTitle := "Cancel KVM Consent"
+	requestSolConsentTarget := fmt.Sprintf("/redfish/v1/Systems/%s/Actions/Oem/IntelComputerSystem.RequestSolConsent", systemID)
+	requestSolConsentTitle := "Request SOL Consent"
+	submitSolConsentCodeTarget := fmt.Sprintf("/redfish/v1/Systems/%s/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode", systemID)
+	submitSolConsentCodeTitle := "Submit SOL Consent Code"
+	cancelSolConsentTarget := fmt.Sprintf("/redfish/v1/Systems/%s/Actions/Oem/IntelComputerSystem.CancelSolConsent", systemID)
+	cancelSolConsentTitle := "Cancel SOL Consent"
 
 	// Create the ComputerSystem.Reset action
 	resetAction := &generated.ComputerSystemReset{
@@ -855,6 +876,18 @@ func (uc *ComputerSystemUseCase) createActionsStruct(systemID string) *generated
 		Target: &cancelConsentTarget,
 		Title:  &cancelConsentTitle,
 	}
+	requestSolConsentAction := &generated.ComputerSystemOemIntelAmtRequestSolConsent{
+		Target: &requestSolConsentTarget,
+		Title:  &requestSolConsentTitle,
+	}
+	submitSolConsentCodeAction := &generated.ComputerSystemOemIntelAmtSubmitSolConsentCode{
+		Target: &submitSolConsentCodeTarget,
+		Title:  &submitSolConsentCodeTitle,
+	}
+	cancelSolConsentAction := &generated.ComputerSystemOemIntelAmtCancelSolConsent{
+		Target: &cancelSolConsentTarget,
+		Title:  &cancelSolConsentTitle,
+	}
 
 	// Create and return the Actions structure
 	return &generated.ComputerSystemActions{
@@ -864,6 +897,9 @@ func (uc *ComputerSystemUseCase) createActionsStruct(systemID string) *generated
 			HashOemIntelAMTRequestKVMConsent:        requestConsentAction,
 			HashOemIntelAMTSubmitKVMConsentCode:     submitConsentCodeAction,
 			HashOemIntelAMTCancelKVMConsent:         cancelConsentAction,
+			HashOemIntelAMTRequestSolConsent:        requestSolConsentAction,
+			HashOemIntelAMTSubmitSolConsentCode:     submitSolConsentCodeAction,
+			HashOemIntelAMTCancelSolConsent:         cancelSolConsentAction,
 		},
 	}
 }

--- a/redfish/internal/usecase/computer_system_fuzz_test.go
+++ b/redfish/internal/usecase/computer_system_fuzz_test.go
@@ -350,7 +350,7 @@ func FuzzPowerStateConversion(f *testing.F) {
 }
 
 // FuzzSolConsentCode fuzzes SubmitSolConsentCode with arbitrary consent code strings.
-// Verifies: no panics, deterministic error handling, valid/invalid codes handled correctly.
+// Verifies: no panics and deterministic error behavior for identical inputs.
 func FuzzSolConsentCode(f *testing.F) {
 	seeds := []string{
 		"123456",

--- a/redfish/internal/usecase/computer_system_fuzz_test.go
+++ b/redfish/internal/usecase/computer_system_fuzz_test.go
@@ -115,6 +115,30 @@ func (r *fuzzMockRepo) CancelKVMConsent(_ context.Context, systemID string) erro
 	return nil
 }
 
+func (r *fuzzMockRepo) RequestSolConsent(_ context.Context, systemID string) error {
+	if _, ok := r.systems[systemID]; !ok {
+		return ErrSystemNotFound
+	}
+
+	return nil
+}
+
+func (r *fuzzMockRepo) SubmitSolConsentCode(_ context.Context, systemID, _ string) error {
+	if _, ok := r.systems[systemID]; !ok {
+		return ErrSystemNotFound
+	}
+
+	return nil
+}
+
+func (r *fuzzMockRepo) CancelSolConsent(_ context.Context, systemID string) error {
+	if _, ok := r.systems[systemID]; !ok {
+		return ErrSystemNotFound
+	}
+
+	return nil
+}
+
 // newFuzzUseCase returns a ComputerSystemUseCase backed by the inline mock repository.
 func newFuzzUseCase() *ComputerSystemUseCase {
 	return &ComputerSystemUseCase{Repo: newFuzzMockRepo()}
@@ -321,6 +345,100 @@ func FuzzPowerStateConversion(f *testing.F) {
 
 		if result == nil {
 			t.Fatal("expected non-nil result")
+		}
+	})
+}
+
+// FuzzSolConsentCode fuzzes SubmitSolConsentCode with arbitrary consent code strings.
+// Verifies: no panics, deterministic error handling, valid/invalid codes handled correctly.
+func FuzzSolConsentCode(f *testing.F) {
+	seeds := []string{
+		"123456",
+		"000000",
+		"999999",
+		"",
+		"12345",
+		"1234567",
+		"abcdef",
+		"12ab56",
+		strings.Repeat("1", 4096),
+		"123\x00456",
+		"용戶🙂секрет",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	uc := newFuzzUseCase()
+	ctx := context.Background()
+
+	f.Fuzz(func(t *testing.T, consentCode string) {
+		// Must never panic regardless of input.
+		err1 := uc.SubmitSolConsentCode(ctx, fuzzTestSystemID, consentCode)
+		err2 := uc.SubmitSolConsentCode(ctx, fuzzTestSystemID, consentCode)
+
+		if (err1 == nil) != (err2 == nil) {
+			t.Fatalf("non-deterministic error for consentCode %q: first=%v second=%v", consentCode, err1, err2)
+		}
+	})
+}
+
+// FuzzRequestSolConsent fuzzes RequestSolConsent with arbitrary system ID values.
+// Verifies: no panics, deterministic results for the same ID.
+func FuzzRequestSolConsent(f *testing.F) {
+	seeds := []string{
+		fuzzTestSystemID,
+		"",
+		"not-a-uuid",
+		"00000000-0000-0000-0000-000000000000",
+		strings.Repeat("a", 4096),
+		"../etc/passwd",
+		"550e8400-e29b-41d4-a716-446655440001\x00extra",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	uc := newFuzzUseCase()
+	ctx := context.Background()
+
+	f.Fuzz(func(t *testing.T, systemID string) {
+		err1 := uc.RequestSolConsent(ctx, systemID)
+		err2 := uc.RequestSolConsent(ctx, systemID)
+
+		if (err1 == nil) != (err2 == nil) {
+			t.Fatalf("non-deterministic error for systemID %q: first=%v second=%v", systemID, err1, err2)
+		}
+	})
+}
+
+// FuzzCancelSolConsent fuzzes CancelSolConsent with arbitrary system ID values.
+// Verifies: no panics, deterministic results for the same ID.
+func FuzzCancelSolConsent(f *testing.F) {
+	seeds := []string{
+		fuzzTestSystemID,
+		"",
+		"not-a-uuid",
+		"00000000-0000-0000-0000-000000000000",
+		strings.Repeat("a", 4096),
+		"../etc/passwd",
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	uc := newFuzzUseCase()
+	ctx := context.Background()
+
+	f.Fuzz(func(t *testing.T, systemID string) {
+		err1 := uc.CancelSolConsent(ctx, systemID)
+		err2 := uc.CancelSolConsent(ctx, systemID)
+
+		if (err1 == nil) != (err2 == nil) {
+			t.Fatalf("non-deterministic error for systemID %q: first=%v second=%v", systemID, err1, err2)
 		}
 	})
 }

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -79,6 +79,18 @@ func (r *graphicalConsoleTestRepo) CancelKVMConsent(_ context.Context, _ string)
 	return r.ccErr
 }
 
+func (r *graphicalConsoleTestRepo) RequestSolConsent(_ context.Context, _ string) error {
+	return r.ccErr
+}
+
+func (r *graphicalConsoleTestRepo) SubmitSolConsentCode(_ context.Context, _, _ string) error {
+	return r.ccErr
+}
+
+func (r *graphicalConsoleTestRepo) CancelSolConsent(_ context.Context, _ string) error {
+	return r.ccErr
+}
+
 func TestConvertGraphicalConsoleToGeneratedNil(t *testing.T) {
 	t.Parallel()
 
@@ -735,6 +747,96 @@ func TestCancelKVMConsent(t *testing.T) {
 	}
 }
 
+func TestRequestSolConsent(t *testing.T) {
+	t.Parallel()
+
+	errAMT := errors.New("amt refused")
+
+	tests := []struct {
+		name    string
+		repoErr error
+		wantErr error
+	}{
+		{name: "success"},
+		{name: "repo error", repoErr: errAMT, wantErr: errAMT},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc := &ComputerSystemUseCase{Repo: &graphicalConsoleTestRepo{ccErr: tt.repoErr}}
+
+			err := uc.RequestSolConsent(context.Background(), "system-1")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("RequestSolConsent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestSubmitSolConsentCode(t *testing.T) {
+	t.Parallel()
+
+	errAMT := errors.New("amt refused")
+
+	tests := []struct {
+		name    string
+		repoErr error
+		wantErr error
+	}{
+		{name: "success"},
+		{name: "repo error", repoErr: errAMT, wantErr: errAMT},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc := &ComputerSystemUseCase{Repo: &graphicalConsoleTestRepo{ccErr: tt.repoErr}}
+
+			err := uc.SubmitSolConsentCode(context.Background(), "system-1", "123456")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("SubmitSolConsentCode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCancelSolConsent(t *testing.T) {
+	t.Parallel()
+
+	errAMT := errors.New("amt refused")
+
+	tests := []struct {
+		name    string
+		repoErr error
+		wantErr error
+	}{
+		{name: "success"},
+		{name: "repo error", repoErr: errAMT, wantErr: errAMT},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			uc := &ComputerSystemUseCase{Repo: &graphicalConsoleTestRepo{ccErr: tt.repoErr}}
+
+			err := uc.CancelSolConsent(context.Background(), "system-1")
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CancelSolConsent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
 func TestGetComputerSystemIncludesGenerateRedirectionTokenAction(t *testing.T) {
 	t.Parallel()
 
@@ -760,29 +862,7 @@ func TestGetComputerSystemIncludesGenerateRedirectionTokenAction(t *testing.T) {
 		t.Fatal("expected Actions to be present")
 	}
 
-	if result.Actions.HashComputerSystemReset == nil {
-		t.Fatal("expected #ComputerSystem.Reset action to be present")
-	}
-
-	if result.Actions.Oem == nil {
-		t.Fatal("expected OEM actions to be present")
-	}
-
-	if result.Actions.Oem.HashOemIntelAMTGenerateRedirectionToken == nil {
-		t.Fatal("expected #Oem.Intel.AMT.GenerateRedirectionToken action to be present")
-	}
-
-	if result.Actions.Oem.HashOemIntelAMTRequestKVMConsent == nil {
-		t.Fatal("expected #Oem.Intel.AMT.RequestKVMConsent action to be present")
-	}
-
-	if result.Actions.Oem.HashOemIntelAMTSubmitKVMConsentCode == nil {
-		t.Fatal("expected #Oem.Intel.AMT.SubmitKVMConsentCode action to be present")
-	}
-
-	if result.Actions.Oem.HashOemIntelAMTCancelKVMConsent == nil {
-		t.Fatal("expected #Oem.Intel.AMT.CancelKVMConsent action to be present")
-	}
+	assertRequiredOemActions(t, result.Actions)
 
 	action := result.Actions.Oem.HashOemIntelAMTGenerateRedirectionToken
 	expectedTarget := "/redfish/v1/Systems/system-1/Actions/Oem/IntelComputerSystem.GenerateRedirectionToken"
@@ -807,6 +887,59 @@ func TestGetComputerSystemIncludesGenerateRedirectionTokenAction(t *testing.T) {
 	assertActionTarget(t, "request", requestAction.Target, requestTarget)
 	assertActionTarget(t, "submit", submitAction.Target, submitTarget)
 	assertActionTarget(t, "cancel", cancelAction.Target, cancelTarget)
+
+	requestSolAction := result.Actions.Oem.HashOemIntelAMTRequestSolConsent
+	requestSolTarget := "/redfish/v1/Systems/system-1/Actions/Oem/IntelComputerSystem.RequestSolConsent"
+
+	submitSolAction := result.Actions.Oem.HashOemIntelAMTSubmitSolConsentCode
+	submitSolTarget := "/redfish/v1/Systems/system-1/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode"
+
+	cancelSolAction := result.Actions.Oem.HashOemIntelAMTCancelSolConsent
+	cancelSolTarget := "/redfish/v1/Systems/system-1/Actions/Oem/IntelComputerSystem.CancelSolConsent"
+
+	assertActionTarget(t, "sol-request", requestSolAction.Target, requestSolTarget)
+	assertActionTarget(t, "sol-submit", submitSolAction.Target, submitSolTarget)
+	assertActionTarget(t, "sol-cancel", cancelSolAction.Target, cancelSolTarget)
+}
+
+func assertRequiredOemActions(t *testing.T, actions *generated.ComputerSystemActions) {
+	t.Helper()
+
+	if actions.HashComputerSystemReset == nil {
+		t.Fatal("expected #ComputerSystem.Reset action to be present")
+	}
+
+	if actions.Oem == nil {
+		t.Fatal("expected OEM actions to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTGenerateRedirectionToken == nil {
+		t.Fatal("expected #Oem.Intel.AMT.GenerateRedirectionToken action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTRequestKVMConsent == nil {
+		t.Fatal("expected #Oem.Intel.AMT.RequestKVMConsent action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTSubmitKVMConsentCode == nil {
+		t.Fatal("expected #Oem.Intel.AMT.SubmitKVMConsentCode action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTCancelKVMConsent == nil {
+		t.Fatal("expected #Oem.Intel.AMT.CancelKVMConsent action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTRequestSolConsent == nil {
+		t.Fatal("expected #Oem.Intel.AMT.RequestSolConsent action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTSubmitSolConsentCode == nil {
+		t.Fatal("expected #Oem.Intel.AMT.SubmitSolConsentCode action to be present")
+	}
+
+	if actions.Oem.HashOemIntelAMTCancelSolConsent == nil {
+		t.Fatal("expected #Oem.Intel.AMT.CancelSolConsent action to be present")
+	}
 }
 
 func assertActionTarget(t *testing.T, actionName string, got *string, want string) {

--- a/redfish/internal/usecase/consent_errors.go
+++ b/redfish/internal/usecase/consent_errors.go
@@ -7,6 +7,15 @@ const (
 	consentOperationSubmit  = "SubmitKVMConsentCode"
 	consentOperationCancel  = "CancelKVMConsent"
 
+	consentOperationSolRequest = "RequestSolConsent"
+	consentOperationSolSubmit  = "SubmitSolConsentCode"
+	consentOperationSolCancel  = "CancelSolConsent"
+
+	consentMsgRequestInvalidState = "cannot request consent in the current opt-in state"
+	consentMsgSubmitInvalidState  = "cannot submit consent code in the current opt-in state"
+	consentMsgCancelInvalidState  = "cannot cancel consent in the current opt-in state"
+	consentMsgCodeRejected        = "consent code was rejected by AMT"
+
 	consentReturnValueInvalidState       = 2
 	consentReturnValueOperationNotReady  = 3
 	consentReturnValueConsentCodeInvalid = 2066
@@ -30,30 +39,30 @@ func consentReturnValueMessage(operation string, returnValue int) (string, bool)
 	switch returnValue {
 	case consentReturnValueInvalidState:
 		switch operation {
-		case consentOperationRequest:
-			return "cannot request consent in the current opt-in state", true
-		case consentOperationSubmit:
-			return "cannot submit consent code in the current opt-in state", true
-		case consentOperationCancel:
-			return "cannot cancel consent in the current opt-in state", true
+		case consentOperationRequest, consentOperationSolRequest:
+			return consentMsgRequestInvalidState, true
+		case consentOperationSubmit, consentOperationSolSubmit:
+			return consentMsgSubmitInvalidState, true
+		case consentOperationCancel, consentOperationSolCancel:
+			return consentMsgCancelInvalidState, true
 		default:
 			return "operation is not allowed in the current AMT opt-in state", true
 		}
 	case consentReturnValueOperationNotReady:
 		switch operation {
-		case consentOperationRequest:
+		case consentOperationRequest, consentOperationSolRequest:
 			return "cannot request consent because AMT is not ready for this operation in the current configuration/state", true
-		case consentOperationSubmit:
+		case consentOperationSubmit, consentOperationSolSubmit:
 			return "cannot submit consent code because AMT is not ready for this operation in the current configuration/state", true
-		case consentOperationCancel:
+		case consentOperationCancel, consentOperationSolCancel:
 			return "cannot cancel consent because AMT is not ready for this operation in the current configuration/state", true
 		default:
 			return "operation cannot proceed because AMT is not ready in the current configuration/state", true
 		}
 	case consentReturnValueConsentCodeInvalid:
 		switch operation {
-		case consentOperationSubmit:
-			return "consent code was rejected by AMT", true
+		case consentOperationSubmit, consentOperationSolSubmit:
+			return consentMsgCodeRejected, true
 		default:
 			return "operation failed due to AMT consent validation error", true
 		}

--- a/redfish/internal/usecase/consent_errors_test.go
+++ b/redfish/internal/usecase/consent_errors_test.go
@@ -90,3 +90,74 @@ func TestConsentFailedErrorMessage_FallbackFormat(t *testing.T) {
 		t.Fatalf("ConsentFailedError.Error() = %q, want %q", got, want)
 	}
 }
+
+func TestConsentFailedErrorMessage_SolOperations(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		err        *ConsentFailedError
+		wantSubstr string
+	}{
+		{
+			name:       "sol request return value 2",
+			err:        &ConsentFailedError{Operation: consentOperationSolRequest, ReturnValue: consentReturnValueInvalidState},
+			wantSubstr: "cannot request consent in the current opt-in state",
+		},
+		{
+			name:       "sol submit return value 2",
+			err:        &ConsentFailedError{Operation: consentOperationSolSubmit, ReturnValue: consentReturnValueInvalidState},
+			wantSubstr: "cannot submit consent code in the current opt-in state",
+		},
+		{
+			name:       "sol cancel return value 2",
+			err:        &ConsentFailedError{Operation: consentOperationSolCancel, ReturnValue: consentReturnValueInvalidState},
+			wantSubstr: "cannot cancel consent in the current opt-in state",
+		},
+		{
+			name:       "sol request return value 3",
+			err:        &ConsentFailedError{Operation: consentOperationSolRequest, ReturnValue: consentReturnValueOperationNotReady},
+			wantSubstr: "cannot request consent because AMT is not ready",
+		},
+		{
+			name:       "sol submit return value 3",
+			err:        &ConsentFailedError{Operation: consentOperationSolSubmit, ReturnValue: consentReturnValueOperationNotReady},
+			wantSubstr: "cannot submit consent code because AMT is not ready",
+		},
+		{
+			name:       "sol cancel return value 3",
+			err:        &ConsentFailedError{Operation: consentOperationSolCancel, ReturnValue: consentReturnValueOperationNotReady},
+			wantSubstr: "cannot cancel consent because AMT is not ready",
+		},
+		{
+			name:       "sol submit return value 2066",
+			err:        &ConsentFailedError{Operation: consentOperationSolSubmit, ReturnValue: consentReturnValueConsentCodeInvalid},
+			wantSubstr: "consent code was rejected by AMT",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.err.Error()
+			if !strings.Contains(got, tt.wantSubstr) {
+				t.Fatalf("ConsentFailedError.Error() = %q, want substring %q", got, tt.wantSubstr)
+			}
+		})
+	}
+}
+
+func TestConsentFailedErrorMessage_SolFallbackFormat(t *testing.T) {
+	t.Parallel()
+
+	err := &ConsentFailedError{Operation: consentOperationSolRequest, ReturnValue: 5}
+	got := err.Error()
+	want := "RequestSolConsent failed with ReturnValue=5"
+
+	if got != want {
+		t.Fatalf("ConsentFailedError.Error() = %q, want %q", got, want)
+	}
+}

--- a/redfish/internal/usecase/interfaces.go
+++ b/redfish/internal/usecase/interfaces.go
@@ -20,4 +20,7 @@ type ComputerSystemRepository interface {
 	RequestKVMConsent(ctx context.Context, systemID string) error
 	SubmitKVMConsentCode(ctx context.Context, systemID, consentCode string) error
 	CancelKVMConsent(ctx context.Context, systemID string) error
+	RequestSolConsent(ctx context.Context, systemID string) error
+	SubmitSolConsentCode(ctx context.Context, systemID, consentCode string) error
+	CancelSolConsent(ctx context.Context, systemID string) error
 }

--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -1287,7 +1287,7 @@ func determineSOLUserConsentStatus(userConsent string, optInState int, controlMo
 }
 
 // isSOLConsentRequired checks if SOL user consent is required.
-// In CCM mode, consent is always required. In ACM mode, it's only required if userConsent is "sol" or "all".
+// In CCM mode, consent is always required. Otherwise, it's only required if userConsent is "sol" or "all".
 func isSOLConsentRequired(userConsent, controlMode string) bool {
 	consentMode := strings.ToLower(strings.TrimSpace(userConsent))
 	normalizedControlMode := strings.TrimSpace(controlMode)

--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -141,6 +141,9 @@ var (
 
 	// ErrKVMConsentNotRequiredInACM is returned when requesting user consent in ACM mode.
 	ErrKVMConsentNotRequiredInACM = errors.New("KVM user consent is not required in ACM mode")
+
+	// ErrSOLConsentNotRequiredInACM is returned when requesting SOL user consent in ACM mode.
+	ErrSOLConsentNotRequiredInACM = errors.New("SOL user consent is not required in ACM mode")
 )
 
 // CIMObjectType represents different types of CIM objects.
@@ -1721,4 +1724,67 @@ func (r *WsmanComputerSystemRepo) applyBootMode(boot *generated.ComputerSystemBo
 	case generated.Legacy:
 		r.log.Info("Legacy boot mode requested", "systemID", systemID)
 	}
+}
+
+// RequestSolConsent initiates a user consent request for SOL.
+func (r *WsmanComputerSystemRepo) RequestSolConsent(ctx context.Context, systemID string) error {
+	controlMode := strings.TrimSpace(r.getAMTControlMode(ctx, systemID))
+	if strings.EqualFold(controlMode, controlModeACM) {
+		return ErrSOLConsentNotRequiredInACM
+	}
+
+	resp, err := r.usecase.GetUserConsentCode(ctx, systemID)
+	if r.isDeviceNotFoundError(err) {
+		return ErrSystemNotFound
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if resp.Body.ReturnValue != 0 {
+		return &ConsentFailedError{Operation: consentOperationRequest, ReturnValue: resp.Body.ReturnValue}
+	}
+
+	return nil
+}
+
+// SubmitSolConsentCode submits the six-digit user consent code for SOL.
+func (r *WsmanComputerSystemRepo) SubmitSolConsentCode(ctx context.Context, systemID, consentCode string) error {
+	if !isSixDigitNumeric(consentCode) {
+		return ErrInvalidConsentCode
+	}
+
+	resp, err := r.usecase.SendConsentCode(ctx, dto.UserConsentCode{ConsentCode: consentCode}, systemID)
+	if r.isDeviceNotFoundError(err) {
+		return ErrSystemNotFound
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if resp.Body.ReturnValue != 0 {
+		return &ConsentFailedError{Operation: consentOperationSubmit, ReturnValue: resp.Body.ReturnValue}
+	}
+
+	return nil
+}
+
+// CancelSolConsent cancels a pending SOL user consent request.
+func (r *WsmanComputerSystemRepo) CancelSolConsent(ctx context.Context, systemID string) error {
+	resp, err := r.usecase.CancelUserConsent(ctx, systemID)
+	if r.isDeviceNotFoundError(err) {
+		return ErrSystemNotFound
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if resp.Body.ReturnValue != 0 {
+		return &ConsentFailedError{Operation: consentOperationCancel, ReturnValue: resp.Body.ReturnValue}
+	}
+
+	return nil
 }

--- a/redfish/internal/usecase/wsman_repo.go
+++ b/redfish/internal/usecase/wsman_repo.go
@@ -54,7 +54,9 @@ const (
 	controlModeACM          = "ACM"
 	controlModeCCM          = "CCM"
 	userConsentKVM          = "kvm"
+	userConsentSOL          = "sol"
 	userConsentAll          = "all"
+	userConsentNone         = "none"
 	userConsentNotRequired  = "NotRequired"
 	userConsentRequired     = "Required"
 	userConsentRequested    = "Requested"
@@ -1255,6 +1257,48 @@ func isKVMConsentRequired(userConsent, controlMode string) bool {
 	return consentMode == userConsentKVM || consentMode == userConsentAll
 }
 
+// determineSOLUserConsentStatus determines the SOL user consent status based on opt-in state.
+// In ACM mode, consent is never required by policy, so returns NotRequired.
+// In CCM mode, SOL consent is always treated as required; the status is derived from the current opt-in state.
+func determineSOLUserConsentStatus(userConsent string, optInState int, controlMode string) string {
+	if strings.EqualFold(strings.TrimSpace(controlMode), controlModeACM) {
+		return userConsentNotRequired
+	}
+
+	consentRequired := isSOLConsentRequired(userConsent, controlMode)
+	if consentRequired || optInState != int(optin.NotStarted) {
+		switch optInState {
+		case int(optin.NotStarted):
+			return userConsentRequired
+		case int(optin.Requested), int(optin.Displayed):
+			return userConsentRequested
+		case int(optin.Received), int(optin.InSession):
+			return userConsentGranted
+		case optInStateDeniedRaw:
+			return userConsentDenied
+		case optInStateTimeoutRaw:
+			return userConsentTimeout
+		default:
+			return userConsentRequested
+		}
+	}
+
+	return userConsentNotRequired
+}
+
+// isSOLConsentRequired checks if SOL user consent is required.
+// In CCM mode, consent is always required. In ACM mode, it's only required if userConsent is "sol" or "all".
+func isSOLConsentRequired(userConsent, controlMode string) bool {
+	consentMode := strings.ToLower(strings.TrimSpace(userConsent))
+	normalizedControlMode := strings.TrimSpace(controlMode)
+
+	if strings.EqualFold(normalizedControlMode, controlModeCCM) {
+		return true
+	}
+
+	return consentMode == userConsentSOL || consentMode == userConsentAll
+}
+
 func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2 dtov2.Features, controlMode string) *redfishv1.ComputerSystemHostSerialConsole {
 	serviceEnabled := featuresV2.EnableSOL
 	maxConcurrentSessions := int64(1)
@@ -1267,16 +1311,30 @@ func (r *WsmanComputerSystemRepo) buildSerialConsole(systemID string, featuresV2
 		consoleURI = &uri
 	}
 
-	solStatus := determineSOLStatus(featuresV2.EnableSOL, featuresV2.Redirection, featuresV2.UserConsent, featuresV2.OptInState)
+	normalizedUserConsent := strings.ToLower(strings.TrimSpace(featuresV2.UserConsent))
+
+	consentModeForSOLStatus := normalizedUserConsent
+	if strings.EqualFold(strings.TrimSpace(controlMode), controlModeACM) {
+		// In ACM mode, preserve Active status when in an active session
+		if featuresV2.OptInState == int(optin.InSession) {
+			consentModeForSOLStatus = userConsentSOL
+		} else {
+			consentModeForSOLStatus = userConsentNone
+		}
+	} else if isSOLConsentRequired(normalizedUserConsent, controlMode) {
+		consentModeForSOLStatus = userConsentSOL
+	}
+
+	solStatus := determineSOLStatus(featuresV2.EnableSOL, featuresV2.Redirection, consentModeForSOLStatus, featuresV2.OptInState)
+	solUserConsentStatus := determineSOLUserConsentStatus(normalizedUserConsent, featuresV2.OptInState, controlMode)
 
 	// Build OEM extensions with Intel AMT status.
 	oemExt := &redfishv1.ComputerSystemHostSerialConsoleOEM{
 		Intel: &redfishv1.ComputerSystemHostSerialConsoleIntel{
 			AMT: &redfishv1.ComputerSystemHostSerialConsoleAMT{
-				ControlMode: controlMode,
-				SOLStatus:   solStatus,
-				// Planned follow-up: query AMT_RedirectionService and IPS_OptInService for actual user consent status.
-				UserConsentStatus: userConsentNotRequired,
+				ControlMode:       controlMode,
+				SOLStatus:         solStatus,
+				UserConsentStatus: solUserConsentStatus,
 			},
 		},
 	}
@@ -1743,7 +1801,7 @@ func (r *WsmanComputerSystemRepo) RequestSolConsent(ctx context.Context, systemI
 	}
 
 	if resp.Body.ReturnValue != 0 {
-		return &ConsentFailedError{Operation: consentOperationRequest, ReturnValue: resp.Body.ReturnValue}
+		return &ConsentFailedError{Operation: consentOperationSolRequest, ReturnValue: resp.Body.ReturnValue}
 	}
 
 	return nil
@@ -1765,7 +1823,7 @@ func (r *WsmanComputerSystemRepo) SubmitSolConsentCode(ctx context.Context, syst
 	}
 
 	if resp.Body.ReturnValue != 0 {
-		return &ConsentFailedError{Operation: consentOperationSubmit, ReturnValue: resp.Body.ReturnValue}
+		return &ConsentFailedError{Operation: consentOperationSolSubmit, ReturnValue: resp.Body.ReturnValue}
 	}
 
 	return nil
@@ -1783,7 +1841,7 @@ func (r *WsmanComputerSystemRepo) CancelSolConsent(ctx context.Context, systemID
 	}
 
 	if resp.Body.ReturnValue != 0 {
-		return &ConsentFailedError{Operation: consentOperationCancel, ReturnValue: resp.Body.ReturnValue}
+		return &ConsentFailedError{Operation: consentOperationSolCancel, ReturnValue: resp.Body.ReturnValue}
 	}
 
 	return nil

--- a/redfish/internal/usecase/wsman_repo_test.go
+++ b/redfish/internal/usecase/wsman_repo_test.go
@@ -1533,6 +1533,17 @@ func TestBuildSerialConsole(t *testing.T) {
 			wantControlMode:       controlModeCCM,
 			wantUserConsentStatus: userConsentGranted,
 		},
+		{
+			name:                  "ACM with no consent but in session - active",
+			systemID:              "system-1",
+			features:              dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "none", OptInState: int(optin.InSession)},
+			controlMode:           controlModeACM,
+			wantEnabled:           true,
+			wantURI:               "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus:         solStatusActive,
+			wantControlMode:       controlModeACM,
+			wantUserConsentStatus: userConsentNotRequired,
+		},
 	}
 
 	for _, tt := range tests {

--- a/redfish/internal/usecase/wsman_repo_test.go
+++ b/redfish/internal/usecase/wsman_repo_test.go
@@ -599,6 +599,49 @@ func TestDetermineKVMUserConsentStatus(t *testing.T) {
 	}
 }
 
+func TestDetermineSOLUserConsentStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		userConsent string
+		optInState  int
+		controlMode string
+		want        string
+	}{
+		{name: "sol requested status", userConsent: "sol", optInState: int(optin.Requested), want: userConsentRequested},
+		{name: "all requested status", userConsent: "all", optInState: int(optin.Displayed), want: userConsentRequested},
+		{name: "sol uppercase required status", userConsent: "SOL", optInState: int(optin.NotStarted), want: userConsentRequired},
+		{name: "all with spaces required status", userConsent: "  all  ", optInState: int(optin.NotStarted), want: userConsentRequired},
+		{name: "received maps to granted", userConsent: "sol", optInState: int(optin.Received), want: userConsentGranted},
+		{name: "in-session maps to granted", userConsent: "sol", optInState: int(optin.InSession), want: userConsentGranted},
+		{name: "raw denied state maps to denied", userConsent: "sol", optInState: optInStateDeniedRaw, want: userConsentDenied},
+		{name: "raw timeout state maps to timeout", userConsent: "sol", optInState: optInStateTimeoutRaw, want: userConsentTimeout},
+		{name: "unknown required state falls back to requested", userConsent: "sol", optInState: 999, want: userConsentRequested},
+		{name: "none not required", userConsent: "none", want: userConsentNotRequired},
+		{name: "none with requested flow maps to requested", userConsent: "none", optInState: int(optin.Requested), want: userConsentRequested},
+		{name: "none with received flow maps to granted", userConsent: "none", optInState: int(optin.Received), want: userConsentGranted},
+		{name: "empty not required", userConsent: "", want: userConsentNotRequired},
+		{name: "CCM requires required when none configured", userConsent: "none", optInState: int(optin.NotStarted), controlMode: controlModeCCM, want: userConsentRequired},
+		{name: "CCM with received maps to granted", userConsent: "none", optInState: int(optin.Received), controlMode: controlModeCCM, want: userConsentGranted},
+		{name: "ACM requested remains not required", userConsent: "sol", optInState: int(optin.Requested), controlMode: controlModeACM, want: userConsentNotRequired},
+		{name: "ACM in-session remains not required", userConsent: "sol", optInState: int(optin.InSession), controlMode: controlModeACM, want: userConsentNotRequired},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := determineSOLUserConsentStatus(tt.userConsent, tt.optInState, tt.controlMode)
+			if got != tt.want {
+				t.Fatalf("determineSOLUserConsentStatus() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDetermineSOLStatus(t *testing.T) {
 	t.Parallel()
 
@@ -1368,7 +1411,7 @@ func TestIsSixDigitNumeric(t *testing.T) {
 	}
 }
 
-func assertSerialConsoleOEM(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantSOLStatus string) {
+func assertSerialConsoleOEM(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantSOLStatus, wantControlMode, wantUserConsentStatus string) {
 	t.Helper()
 
 	if got.OEM == nil || got.OEM.Intel == nil || got.OEM.Intel.AMT == nil {
@@ -1381,16 +1424,16 @@ func assertSerialConsoleOEM(t *testing.T, got *redfishv1.ComputerSystemHostSeria
 		t.Errorf("SOLStatus = %q, want %q", amt.SOLStatus, wantSOLStatus)
 	}
 
-	if amt.ControlMode != "ACM" {
-		t.Errorf("ControlMode = %q, want %q", amt.ControlMode, "ACM")
+	if amt.ControlMode != wantControlMode {
+		t.Errorf("ControlMode = %q, want %q", amt.ControlMode, wantControlMode)
 	}
 
-	if amt.UserConsentStatus != "NotRequired" {
-		t.Errorf("UserConsentStatus = %q, want %q", amt.UserConsentStatus, "NotRequired")
+	if amt.UserConsentStatus != wantUserConsentStatus {
+		t.Errorf("UserConsentStatus = %q, want %q", amt.UserConsentStatus, wantUserConsentStatus)
 	}
 }
 
-func assertSerialConsole(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantEnabled bool, wantURI, wantSOLStatus string) {
+func assertSerialConsole(t *testing.T, got *redfishv1.ComputerSystemHostSerialConsole, wantEnabled bool, wantURI, wantSOLStatus, wantControlMode, wantUserConsentStatus string) {
 	t.Helper()
 
 	if got == nil {
@@ -1427,7 +1470,7 @@ func assertSerialConsole(t *testing.T, got *redfishv1.ComputerSystemHostSerialCo
 		}
 	}
 
-	assertSerialConsoleOEM(t, got, wantSOLStatus)
+	assertSerialConsoleOEM(t, got, wantSOLStatus, wantControlMode, wantUserConsentStatus)
 }
 
 func TestBuildSerialConsole(t *testing.T) {
@@ -1436,44 +1479,59 @@ func TestBuildSerialConsole(t *testing.T) {
 	repo := &WsmanComputerSystemRepo{log: logger.New("error")}
 
 	tests := []struct {
-		name          string
-		systemID      string
-		features      dtov2.Features
-		wantEnabled   bool
-		wantURI       string
-		wantSOLStatus string
+		name                  string
+		systemID              string
+		features              dtov2.Features
+		controlMode           string
+		wantEnabled           bool
+		wantURI               string
+		wantSOLStatus         string
+		wantControlMode       string
+		wantUserConsentStatus string
 	}{
 		{
-			name:          "SOL not available - no URI",
-			systemID:      "system-1",
-			features:      dtov2.Features{EnableSOL: true, Redirection: false, UserConsent: "none"},
-			wantEnabled:   true,
-			wantURI:       "",
-			wantSOLStatus: StateDisabled,
+			name:                  "SOL not available - no URI",
+			systemID:              "system-1",
+			features:              dtov2.Features{EnableSOL: true, Redirection: false, UserConsent: "none"},
+			controlMode:           controlModeACM,
+			wantEnabled:           true,
+			wantURI:               "",
+			wantSOLStatus:         StateDisabled,
+			wantControlMode:       controlModeACM,
+			wantUserConsentStatus: userConsentNotRequired,
 		},
 		{
-			name:          "SOL available with URI",
-			systemID:      "system-1",
-			features:      dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "none"},
-			wantEnabled:   true,
-			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
-			wantSOLStatus: StateEnabled,
+			name:                  "SOL available with URI",
+			systemID:              "system-1",
+			features:              dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "none"},
+			controlMode:           controlModeACM,
+			wantEnabled:           true,
+			wantURI:               "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus:         StateEnabled,
+			wantControlMode:       controlModeACM,
+			wantUserConsentStatus: userConsentNotRequired,
 		},
 		{
-			name:          "SOL disabled",
-			systemID:      "system-1",
-			features:      dtov2.Features{EnableSOL: false, Redirection: true, UserConsent: "none"},
-			wantEnabled:   false,
-			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
-			wantSOLStatus: StateDisabled,
+			name:                  "SOL disabled",
+			systemID:              "system-1",
+			features:              dtov2.Features{EnableSOL: false, Redirection: true, UserConsent: "none"},
+			controlMode:           controlModeACM,
+			wantEnabled:           false,
+			wantURI:               "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus:         StateDisabled,
+			wantControlMode:       controlModeACM,
+			wantUserConsentStatus: userConsentNotRequired,
 		},
 		{
-			name:          "consent required and in session - active",
-			systemID:      "system-1",
-			features:      dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "sol", OptInState: int(optin.InSession)},
-			wantEnabled:   true,
-			wantURI:       "/relay/webrelay.ashx?host=system-1&mode=sol",
-			wantSOLStatus: solStatusActive,
+			name:                  "consent required and in session - active",
+			systemID:              "system-1",
+			features:              dtov2.Features{EnableSOL: true, Redirection: true, UserConsent: "sol", OptInState: int(optin.InSession)},
+			controlMode:           controlModeCCM,
+			wantEnabled:           true,
+			wantURI:               "/relay/webrelay.ashx?host=system-1&mode=sol",
+			wantSOLStatus:         solStatusActive,
+			wantControlMode:       controlModeCCM,
+			wantUserConsentStatus: userConsentGranted,
 		},
 	}
 
@@ -1483,8 +1541,8 @@ func TestBuildSerialConsole(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := repo.buildSerialConsole(tt.systemID, tt.features, controlModeACM)
-			assertSerialConsole(t, got, tt.wantEnabled, tt.wantURI, tt.wantSOLStatus)
+			got := repo.buildSerialConsole(tt.systemID, tt.features, tt.controlMode)
+			assertSerialConsole(t, got, tt.wantEnabled, tt.wantURI, tt.wantSOLStatus, tt.wantControlMode, tt.wantUserConsentStatus)
 		})
 	}
 }
@@ -1591,7 +1649,7 @@ func TestGetByIDFallsBackToCachedConsoleData(t *testing.T) {
 	}
 
 	assertGraphicalConsole(t, got.GraphicalConsole, true, []string{kvmConnectTypeKVMIP}, 16995, StateEnabled, userConsentNotRequired)
-	assertSerialConsole(t, got.SerialConsole, true, "/relay/webrelay.ashx?host=system-1&mode=sol", StateEnabled)
+	assertSerialConsole(t, got.SerialConsole, true, "/relay/webrelay.ashx?host=system-1&mode=sol", StateEnabled, controlModeACM, userConsentNotRequired)
 }
 
 func TestGetByIDUsesSafeDefaultsWhenConsoleEnrichmentFailsWithoutCache(t *testing.T) {
@@ -1648,7 +1706,7 @@ func TestGetByIDUsesSafeDefaultsWhenConsoleEnrichmentFailsWithoutCache(t *testin
 	}
 
 	assertGraphicalConsole(t, got.GraphicalConsole, false, nil, 0, StateDisabled, userConsentNotRequired)
-	assertSerialConsole(t, got.SerialConsole, false, "", StateDisabled)
+	assertSerialConsole(t, got.SerialConsole, false, "", StateDisabled, controlModeACM, userConsentNotRequired)
 }
 
 func TestIsContextTimeoutOrCancelError(t *testing.T) {
@@ -1775,6 +1833,293 @@ func TestGetCachedControlModeFromDevice(t *testing.T) {
 				t.Errorf("getCachedControlModeFromDevice() = %q, want %q", got, tt.wantMode)
 			}
 		})
+	}
+}
+
+// ============================================================================
+// SOL Consent Repository Tests
+// ============================================================================
+
+func TestRequestSolConsentRepo_ACMReturnsNotRequiredError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+	wsmanMock := mocks.NewMockWSMAN(ctrl)
+	wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+	device := &entity.Device{
+		GUID:     "system-1",
+		TenantID: "tenant-1",
+	}
+
+	management := mocks.NewMockManagement(ctrl)
+
+	repoMock.EXPECT().GetByID(gomock.Any(), device.GUID, "").Return(device, nil).AnyTimes()
+	wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(management, nil).AnyTimes()
+	management.EXPECT().GetAMTVersion().Return([]software.SoftwareIdentity{}, nil).AnyTimes()
+	management.EXPECT().GetSetupAndConfiguration().Return([]setupandconfiguration.SetupAndConfigurationServiceResponse{{ProvisioningMode: setupandconfiguration.AdminControlMode}}, nil).AnyTimes()
+
+	uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+	repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+	err := repo.RequestSolConsent(context.Background(), device.GUID)
+	if !errors.Is(err, ErrSOLConsentNotRequiredInACM) {
+		t.Fatalf("RequestSolConsent() error = %v, wantErr %v", err, ErrSOLConsentNotRequiredInACM)
+	}
+}
+
+func TestSubmitSolConsentCodeRepo(t *testing.T) {
+	t.Parallel()
+
+	errDeviceNotFound := errors.New(ErrMsgDeviceNotFound)
+	errAMT := errors.New("amt refused")
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	tests := []struct {
+		name    string
+		code    string
+		setup   func(*mocks.MockDeviceManagementRepository, *mocks.MockWSMAN, *mocks.MockManagement)
+		wantErr error
+	}{
+		{
+			name: "success",
+			code: "123456",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				gomock.InOrder(
+					repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+					wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+					management.EXPECT().SendConsentCode(gomock.Any()).Return(optin.Response{}, nil),
+				)
+			},
+		},
+		{
+			name:    "invalid consent code",
+			code:    "12345",
+			wantErr: ErrInvalidConsentCode,
+		},
+		{
+			name: "device not found",
+			code: "123456",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(nil, errDeviceNotFound)
+			},
+			wantErr: ErrSystemNotFound,
+		},
+		{
+			name: "wsman error",
+			code: "123456",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				gomock.InOrder(
+					repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+					wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(nil, errAMT),
+				)
+			},
+			wantErr: errAMT,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+			wsmanMock := mocks.NewMockWSMAN(ctrl)
+			wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+			management := mocks.NewMockManagement(ctrl)
+
+			uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+			repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+			if tt.setup != nil {
+				tt.setup(repoMock, wsmanMock, management)
+			}
+
+			err := repo.SubmitSolConsentCode(context.Background(), device.GUID, tt.code)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("SubmitSolConsentCode() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCancelSolConsentRepo(t *testing.T) {
+	t.Parallel()
+
+	errDeviceNotFound := errors.New(ErrMsgDeviceNotFound)
+	errAMT := errors.New("amt refused")
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	tests := []struct {
+		name    string
+		setup   func(*mocks.MockDeviceManagementRepository, *mocks.MockWSMAN, *mocks.MockManagement)
+		wantErr error
+	}{
+		{
+			name: "success",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, management *mocks.MockManagement) {
+				gomock.InOrder(
+					repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+					wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+					management.EXPECT().CancelUserConsentRequest().Return(optin.Response{}, nil),
+				)
+			},
+		},
+		{
+			name: "device not found",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, _ *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(nil, errDeviceNotFound)
+			},
+			wantErr: ErrSystemNotFound,
+		},
+		{
+			name: "wsman error",
+			setup: func(repoMock *mocks.MockDeviceManagementRepository, wsmanMock *mocks.MockWSMAN, _ *mocks.MockManagement) {
+				gomock.InOrder(
+					repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+					wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(nil, errAMT),
+				)
+			},
+			wantErr: errAMT,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+			wsmanMock := mocks.NewMockWSMAN(ctrl)
+			wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+			management := mocks.NewMockManagement(ctrl)
+
+			uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+			repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+			tt.setup(repoMock, wsmanMock, management)
+
+			err := repo.CancelSolConsent(context.Background(), device.GUID)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("CancelSolConsent() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRequestSolConsentRepo_ReturnValueFailure(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+	wsmanMock := mocks.NewMockWSMAN(ctrl)
+	wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+	management := mocks.NewMockManagement(ctrl)
+
+	uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+	repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+	gomock.InOrder(
+		repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+		wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+		management.EXPECT().GetAMTVersion().Return([]software.SoftwareIdentity{}, nil),
+		management.EXPECT().GetSetupAndConfiguration().Return([]setupandconfiguration.SetupAndConfigurationServiceResponse{{ProvisioningMode: setupandconfiguration.ClientControlMode}}, nil),
+		repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+		wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+		management.EXPECT().GetUserConsentCode().Return(optin.Response{
+			Body: optin.Body{StartOptInResponse: optin.StartOptIn_OUTPUT{ReturnValue: 5}},
+		}, nil),
+	)
+
+	err := repo.RequestSolConsent(context.Background(), device.GUID)
+
+	var consentErr *ConsentFailedError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("RequestSolConsent() error type = %T, want *ConsentFailedError", err)
+	}
+}
+
+func TestSubmitSolConsentCodeRepo_ReturnValueFailure(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+	wsmanMock := mocks.NewMockWSMAN(ctrl)
+	wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+	management := mocks.NewMockManagement(ctrl)
+
+	uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+	repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+	gomock.InOrder(
+		repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+		wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+		management.EXPECT().SendConsentCode(gomock.Any()).Return(optin.Response{
+			Body: optin.Body{SendOptInCodeResponse: optin.SendOptInCode_OUTPUT{ReturnValue: 2066}},
+		}, nil),
+	)
+
+	err := repo.SubmitSolConsentCode(context.Background(), device.GUID, "123456")
+
+	var consentErr *ConsentFailedError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("SubmitSolConsentCode() error type = %T, want *ConsentFailedError", err)
+	}
+}
+
+func TestCancelSolConsentRepo_ReturnValueFailure(t *testing.T) {
+	t.Parallel()
+
+	device := &entity.Device{GUID: "system-1", TenantID: "tenant-1"}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	repoMock := mocks.NewMockDeviceManagementRepository(ctrl)
+	wsmanMock := mocks.NewMockWSMAN(ctrl)
+	wsmanMock.EXPECT().Worker().Return().AnyTimes()
+
+	management := mocks.NewMockManagement(ctrl)
+
+	uc := devices.New(repoMock, wsmanMock, mocks.NewMockRedirection(ctrl), logger.New("error"), mocks.MockCrypto{})
+	repo := &WsmanComputerSystemRepo{usecase: uc, log: logger.New("error")}
+
+	gomock.InOrder(
+		repoMock.EXPECT().GetByID(context.Background(), device.GUID, "").Return(device, nil),
+		wsmanMock.EXPECT().SetupWsmanClient(gomock.Any(), gomock.Any(), false, true).Return(management, nil),
+		management.EXPECT().CancelUserConsentRequest().Return(optin.Response{
+			Body: optin.Body{CancelOptInResponse: optin.CancelOptIn_OUTPUT{ReturnValue: 2}},
+		}, nil),
+	)
+
+	err := repo.CancelSolConsent(context.Background(), device.GUID)
+
+	var consentErr *ConsentFailedError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("CancelSolConsent() error type = %T, want *ConsentFailedError", err)
 	}
 }
 


### PR DESCRIPTION
- Implemented SOL consent request/submit/cancel end-to-end.
- Implement user consent status in Serial console.

1. Request Consent
```
curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{}' \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}/Actions/Oem/IntelComputerSystem.RequestSolConsent" \
  | jq .
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "Message": "The request completed successfully.",
        "MessageId": "Base.1.22.0.Success",
        "Resolution": "None",
        "Severity": "OK"
      }
    ],
    "code": "Base.1.22.0.Success",
    "message": "The request completed successfully."
  }
}
```
2. Submit Consent
```
curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{"ConsentCode":"123456"}' \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}/Actions/Oem/IntelComputerSystem.SubmitSolConsentCode" \
  | jq .
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "Message": "The request completed successfully.",
        "MessageId": "Base.1.22.0.Success",
        "Resolution": "None",
        "Severity": "OK"
      }
    ],
    "code": "Base.1.22.0.Success",
    "message": "The request completed successfully."
  }
}
```

3. Serial Console
```curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}" \
  | jq .SerialConsole

{
  "MaxConcurrentSessions": 1,
  "Oem": {
    "Intel": {
      "AMT": {
        "ControlMode": "ACM",
        "SOLStatus": "Enabled",
        "UserConsentStatus": "NotRequired"
      }
    }
  },
  "WebSocket": {
    "ConsoleURI": "/relay/webrelay.ashx?host=32bcccf9-9a56-0db3-48d6-48210b50d7ea&mode=sol",
    "Interactive": true,
    "ServiceEnabled": true
  }
}
```
4. Consent cancel->request->cancel
```
curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{}' \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}/Actions/Oem/IntelComputerSystem.CancelSolConsent" \
  | jq .
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "Message": "CancelSolConsent failed with ReturnValue=2: cannot cancel consent in the current opt-in state (no pending request)",
        "MessageId": "Base.1.22.0.GeneralError",
        "Resolution": "None",
        "Severity": "Critical"
      }
    ],
    "code": "Base.1.22.0.GeneralError",
    "message": "CancelSolConsent failed with ReturnValue=2: cannot cancel consent in the current opt-in state (no pending request)"
  }
}

curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{}' \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}/Actions/Oem/IntelComputerSystem.RequestSolConsent" \
  | jq 
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "Message": "The request completed successfully.",
        "MessageId": "Base.1.22.0.Success",
        "Resolution": "None",
        "Severity": "OK"
      }
    ],
    "code": "Base.1.22.0.Success",
    "message": "The request completed successfully."
  }
}
curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  -H "Content-Type: application/json" \
  -X POST \
  -d '{}' \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID}/Actions/Oem/IntelComputerSystem.CancelSolConsent" \
  | jq .
{
  "error": {
    "@Message.ExtendedInfo": [
      {
        "Message": "The request completed successfully.",
        "MessageId": "Base.1.22.0.Success",
        "Resolution": "None",
        "Severity": "OK"
      }
    ],
    "code": "Base.1.22.0.Success",
    "message": "The request completed successfully."
  }
}
```
5. Map userconsent to required
```
curl -sk -u "${CONSOLE_USER}:${CONSOLE_PASS}" \
  "${CONSOLE_HOST}/redfish/v1/Systems/${SYSTEM_ID_ACM}" \
  | jq .SerialConsole
"SerialConsole": {
    "MaxConcurrentSessions": 1,
    "Oem": {
      "Intel": {
        "AMT": {
          "ControlMode": "CCM",
          "SOLStatus": "Disabled",
          "UserConsentStatus": "Required"
        }
      }
    },

```