### PR TITLE
fix(api): enforce 32-byte JWT key for redirection token signing

### DIFF
--- a/internal/controller/httpapi/v1/devices.go
+++ b/internal/controller/httpapi/v1/devices.go
@@ -21,6 +21,8 @@ type deviceRoutes struct {
 	l logger.Interface
 }
 
+const hs256KeyLengthBytes = 32
+
 var ErrValidationDevices = dto.NotValidError{Console: consoleerrors.CreateConsoleError("ProfileAPI")}
 
 func NewDeviceRoutes(handler *gin.RouterGroup, t devices.Feature, l logger.Interface) {
@@ -78,6 +80,12 @@ func (dr *deviceRoutes) LoginRedirection(c *gin.Context) {
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
+	if !isValidHS256KeyLength(config.ConsoleConfig.JWTKey) {
+		c.JSON(http.StatusInternalServerError, gin.H{errorKey: "invalid JWT signing key length"})
+
+		return
+	}
+
 	tokenString, err := token.SignedString([]byte(config.ConsoleConfig.JWTKey))
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{errorKey: "could not create token"})
@@ -86,6 +94,10 @@ func (dr *deviceRoutes) LoginRedirection(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"token": tokenString})
+}
+
+func isValidHS256KeyLength(key string) bool {
+	return len([]byte(key)) == hs256KeyLengthBytes
 }
 
 func (dr *deviceRoutes) get(c *gin.Context) {

--- a/internal/controller/httpapi/v1/devices_test.go
+++ b/internal/controller/httpapi/v1/devices_test.go
@@ -29,7 +29,7 @@ func setupTestConfig() {
 		if config.ConsoleConfig == nil {
 			config.ConsoleConfig = &config.Config{
 				Auth: config.Auth{
-					JWTKey:                   "test-key",
+					JWTKey:                   "12345678901234567890123456789012",
 					JWTExpiration:            24 * time.Hour,
 					RedirectionJWTExpiration: 5 * time.Minute,
 				},
@@ -552,4 +552,28 @@ func verifyRedirectionTokenExpiration(t *testing.T, tokenString string) {
 	maxWrongExpiration := 24 * time.Hour
 	require.True(t, timeDiff < maxWrongExpiration-time.Hour,
 		"token expiration time %v is suspiciously close to 24 hours (the bug)", timeDiff)
+}
+
+func TestIsValidHS256KeyLength(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		key   string
+		valid bool
+	}{
+		{name: "valid key length", key: "12345678901234567890123456789012", valid: true},
+		{name: "short key", key: "short-key", valid: false},
+		{name: "long key", key: "123456789012345678901234567890123", valid: false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.valid, isValidHS256KeyLength(tc.key))
+		})
+	}
 }


### PR DESCRIPTION
## Summary
- enforce a strict 32-byte key requirement before signing redirection JWTs in the v1 devices controller
- return HTTP 500 with `invalid JWT signing key length` when the configured signing key length is invalid
- keep signing behavior unchanged when key length is valid

## Tests
- update test setup to use a 32-byte JWT key
- add unit test coverage for key-length validation helper

## Notes
- scoped intentionally to redirection token signing in `internal/controller/httpapi/v1/devices.go`
- unrelated local changes were left out of this PR