### PR TITLE
test: add KVM fuzz tests and mock code (#1035)(#1036)

### DIFF
--- a/redfish/internal/controller/http/v1/handler/systems_kvm_fuzz_test.go
+++ b/redfish/internal/controller/http/v1/handler/systems_kvm_fuzz_test.go
@@ -1,0 +1,393 @@
+package v1
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
+	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
+	"github.com/device-management-toolkit/console/redfish/internal/usecase"
+)
+
+// kvmConsentErrorFor maps a fuzz selector to an injected repository error.
+// Each branch exercises a distinct arm of the consent error-handling switch
+// in the KVM consent action handlers (success, not-found, consent failure,
+// ACM-not-required, AMT 400, and generic internal failure).
+func kvmConsentErrorFor(selector uint8) error {
+	switch selector % 6 {
+	case 1:
+		return usecase.ErrSystemNotFound
+	case 2:
+		return &usecase.ConsentFailedError{Operation: "RequestKVMConsent", ReturnValue: 2}
+	case 3:
+		return usecase.ErrKVMConsentNotRequiredInACM
+	case 4:
+		return errors.New("AMT call failed: 400 Bad Request")
+	case 5:
+		return errors.New("unexpected AMT failure")
+	default:
+		return nil
+	}
+}
+
+// kvmUpdateErrorFor maps a fuzz selector to an injected GraphicalConsole update error.
+func kvmUpdateErrorFor(selector uint8) error {
+	switch selector % 3 {
+	case 1:
+		return usecase.ErrSystemNotFound
+	case 2:
+		return errors.New("graphical console update failed")
+	default:
+		return nil
+	}
+}
+
+// disableRouterRedirects turns off gin's path-normalization redirects so fuzzed
+// request paths (e.g. ones that decode to empty or doubled segments) reach the
+// handler instead of short-circuiting with a router-level 3xx redirect. This keeps
+// the fuzz focused on handler logic rather than gin's routing layer.
+func disableRouterRedirects(router *gin.Engine) *gin.Engine {
+	router.RedirectTrailingSlash = false
+	router.RedirectFixedPath = false
+
+	return router
+}
+
+// newKVMConsentFuzzRouter builds a router backed by a repository seeded with the
+// canonical test system. When injectedErr is non-nil it is returned by the
+// consent repository methods for that system, driving the handler error paths.
+func newKVMConsentFuzzRouter(injectedErr error) *gin.Engine {
+	repo := NewTestSystemsComputerSystemRepository()
+	repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test System"})
+
+	if injectedErr != nil {
+		repo.errorOnGetByID[testSystemID] = injectedErr
+	}
+
+	server := setupSystemActionsTestServer(repo)
+
+	return disableRouterRedirects(setupSystemActionsTestRouter(server))
+}
+
+// assertValidKVMActionStatus fails the fuzz iteration if the handler produced a
+// status code outside the contract for KVM action/PATCH endpoints. Any panic in
+// the handler chain surfaces as a test failure automatically.
+func assertValidKVMActionStatus(t *testing.T, w *httptest.ResponseRecorder, systemID, body string) {
+	t.Helper()
+
+	switch w.Code {
+	case http.StatusOK, http.StatusBadRequest, http.StatusNotFound, http.StatusInternalServerError:
+	default:
+		t.Fatalf("unexpected status %d for systemID %q body %q", w.Code, systemID, body)
+	}
+}
+
+// FuzzRequestKVMConsentHandler fuzzes the RequestKVMConsent OEM action handler with
+// arbitrary system IDs, request bodies, and injected repository errors.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzRequestKVMConsentHandler(f *testing.F) {
+	seedInputs := []struct {
+		systemID string
+		body     string
+		errSel   uint8
+	}{
+		{testSystemID, `{}`, 0},
+		{testSystemID, ``, 0},
+		{testSystemID, `{}`, 1},
+		{testSystemID, `{}`, 2},
+		{testSystemID, `{}`, 3},
+		{testSystemID, `{}`, 4},
+		{testSystemID, `{}`, 5},
+		{testSystemID, `not-json`, 0},
+		{testSystemID, `{"unexpected":true}`, 0},
+		{testUUIDNotFound, `{}`, 0},
+		{"not-a-uuid", `{}`, 0},
+		{"", `{}`, 0},
+		{"/", `{}`, 0},
+		{"../etc/passwd", `{}`, 0},
+		{"用戶🙂", `{}`, 0},
+	}
+
+	for _, in := range seedInputs {
+		f.Add(in.systemID, in.body, in.errSel)
+	}
+
+	f.Fuzz(func(t *testing.T, systemID, body string, errSel uint8) {
+		router := newKVMConsentFuzzRouter(kvmConsentErrorFor(errSel))
+
+		target := "/redfish/v1/Systems/" + url.PathEscape(systemID) + "/Actions/Oem/IntelComputerSystem.RequestKVMConsent"
+		req := httptest.NewRequest(http.MethodPost, target, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, systemID, body)
+	})
+}
+
+// FuzzCancelKVMConsentHandler fuzzes the CancelKVMConsent OEM action handler with
+// arbitrary system IDs, request bodies, and injected repository errors.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzCancelKVMConsentHandler(f *testing.F) {
+	seedInputs := []struct {
+		systemID string
+		body     string
+		errSel   uint8
+	}{
+		{testSystemID, `{}`, 0},
+		{testSystemID, ``, 0},
+		{testSystemID, `{}`, 1},
+		{testSystemID, `{}`, 2},
+		{testSystemID, `{}`, 4},
+		{testSystemID, `{}`, 5},
+		{testSystemID, `not-json`, 0},
+		{testUUIDNotFound, `{}`, 0},
+		{"not-a-uuid", `{}`, 0},
+		{"", `{}`, 0},
+		{"/", `{}`, 0},
+		{"用戶🙂", `{}`, 0},
+	}
+
+	for _, in := range seedInputs {
+		f.Add(in.systemID, in.body, in.errSel)
+	}
+
+	f.Fuzz(func(t *testing.T, systemID, body string, errSel uint8) {
+		router := newKVMConsentFuzzRouter(kvmConsentErrorFor(errSel))
+
+		target := "/redfish/v1/Systems/" + url.PathEscape(systemID) + "/Actions/Oem/IntelComputerSystem.CancelKVMConsent"
+		req := httptest.NewRequest(http.MethodPost, target, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, systemID, body)
+	})
+}
+
+// FuzzSubmitKVMConsentCodeHandler fuzzes the SubmitKVMConsentCode OEM action handler
+// with arbitrary system IDs, consent codes, and injected repository errors. This
+// exercises the six-digit consent-code validation as well as the consent error paths.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzSubmitKVMConsentCodeHandler(f *testing.F) {
+	seedInputs := []struct {
+		systemID string
+		code     string
+		errSel   uint8
+	}{
+		{testSystemID, "123456", 0},
+		{testSystemID, "000000", 0},
+		{testSystemID, "123456", 1},
+		{testSystemID, "123456", 2},
+		{testSystemID, "123456", 4},
+		{testSystemID, "123456", 5},
+		{testSystemID, "", 0},
+		{testSystemID, "12345", 0},
+		{testSystemID, "1234567", 0},
+		{testSystemID, "abcdef", 0},
+		{testSystemID, "12 34 56", 0},
+		{testSystemID, " 123456 ", 0},
+		{testSystemID, "１２３４５６", 0},
+		{testUUIDNotFound, "123456", 0},
+		{"not-a-uuid", "123456", 0},
+		{"", "123456", 0},
+		{"/", "123456", 0},
+	}
+
+	for _, in := range seedInputs {
+		f.Add(in.systemID, in.code, in.errSel)
+	}
+
+	f.Fuzz(func(t *testing.T, systemID, code string, errSel uint8) {
+		router := newKVMConsentFuzzRouter(kvmConsentErrorFor(errSel))
+		body := createSubmitKVMConsentCodeRequest(code)
+
+		target := "/redfish/v1/Systems/" + url.PathEscape(systemID) + "/Actions/Oem/IntelComputerSystem.SubmitKVMConsentCode"
+		req := httptest.NewRequest(http.MethodPost, target, bytes.NewBuffer(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, systemID, code)
+	})
+}
+
+// FuzzSubmitKVMConsentCodeRawBody fuzzes the SubmitKVMConsentCode handler with raw,
+// possibly-malformed request bodies to harden the JSON binding path against panics.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzSubmitKVMConsentCodeRawBody(f *testing.F) {
+	seeds := []string{
+		`{"ConsentCode":"123456"}`,
+		`{"ConsentCode":""}`,
+		`{"ConsentCode":123456}`,
+		`{"ConsentCode":null}`,
+		`{}`,
+		``,
+		`not-json`,
+		`{"ConsentCode":"123456"`,
+		`[1,2,3]`,
+		`{"ConsentCode":"١٢٣٤٥٦"}`,
+		`{"ConsentCode":"\u0000\u0000\u0000\u0000\u0000\u0000"}`,
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, rawBody string) {
+		router := newKVMConsentFuzzRouter(nil)
+
+		target := "/redfish/v1/Systems/" + testSystemID + "/Actions/Oem/IntelComputerSystem.SubmitKVMConsentCode"
+		req := httptest.NewRequest(http.MethodPost, target, bytes.NewBufferString(rawBody))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, testSystemID, rawBody)
+	})
+}
+
+// FuzzSubmitKVMConsentCodeJSON fuzzes JSON unmarshalling of the SubmitKVMConsentCode
+// request body type. Verifies: no panics, deterministic parse results, and that a
+// successful parse yields a stable ConsentCode value.
+func FuzzSubmitKVMConsentCodeJSON(f *testing.F) {
+	seeds := []string{
+		`{"ConsentCode":"123456"}`,
+		`{"ConsentCode":""}`,
+		`{"ConsentCode":null}`,
+		`{"ConsentCode":123456}`,
+		`{}`,
+		`{"ConsentCode":"123456","Extra":true}`,
+		`not-json`,
+		`{"ConsentCode":"١٢٣٤٥٦"}`,
+		`{"ConsentCode":"\u0000\u0000\u0000\u0000\u0000\u0000"}`,
+	}
+
+	for _, s := range seeds {
+		f.Add(s)
+	}
+
+	f.Fuzz(func(t *testing.T, payload string) {
+		var (
+			first  generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitKVMConsentCodeJSONRequestBody
+			second generated.PostRedfishV1SystemsComputerSystemIdActionsOemIntelComputerSystemSubmitKVMConsentCodeJSONRequestBody
+		)
+
+		firstErr := json.Unmarshal([]byte(payload), &first)
+		secondErr := json.Unmarshal([]byte(payload), &second)
+
+		if (firstErr == nil) != (secondErr == nil) {
+			t.Fatalf("non-deterministic error for payload %q: first=%v second=%v", payload, firstErr, secondErr)
+		}
+
+		if firstErr != nil {
+			return
+		}
+
+		if first.ConsentCode != second.ConsentCode {
+			t.Fatalf("non-deterministic unmarshal for payload %q: %q vs %q", payload, first.ConsentCode, second.ConsentCode)
+		}
+	})
+}
+
+// FuzzGenerateRedirectionTokenHandler fuzzes the GenerateRedirectionToken OEM action
+// handler (used to authorize KVM/SOL redirection) with arbitrary system IDs and bodies.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzGenerateRedirectionTokenHandler(f *testing.F) {
+	seedInputs := []struct {
+		systemID string
+		body     string
+	}{
+		{testSystemID, `{}`},
+		{testSystemID, ``},
+		{testSystemID, `not-json`},
+		{testUUIDNotFound, `{}`},
+		{"not-a-uuid", `{}`},
+		{"", `{}`},
+		{"用戶🙂", `{}`},
+	}
+
+	for _, in := range seedInputs {
+		f.Add(in.systemID, in.body)
+	}
+
+	f.Fuzz(func(t *testing.T, systemID, body string) {
+		configureTestJWT(t)
+
+		repo := NewTestSystemsComputerSystemRepository()
+		repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test System"})
+		server := setupSystemActionsTestServer(repo)
+		router := disableRouterRedirects(setupSystemActionsTestRouter(server))
+
+		target := "/redfish/v1/Systems/" + url.PathEscape(systemID) + "/Actions/Oem/IntelComputerSystem.GenerateRedirectionToken"
+		req := httptest.NewRequest(http.MethodPost, target, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, systemID, body)
+	})
+}
+
+// FuzzGraphicalConsoleServiceEnabledHandler fuzzes the PATCH ComputerSystem handler that
+// enables or disables the KVM (GraphicalConsole) service, with arbitrary system IDs,
+// bodies, and injected update errors.
+// Verifies: no panics and only contract-defined status codes are returned.
+func FuzzGraphicalConsoleServiceEnabledHandler(f *testing.F) {
+	seedInputs := []struct {
+		systemID string
+		body     string
+		errSel   uint8
+	}{
+		{testSystemID, `{"GraphicalConsole":{"ServiceEnabled":true}}`, 0},
+		{testSystemID, `{"GraphicalConsole":{"ServiceEnabled":false}}`, 0},
+		{testSystemID, `{"GraphicalConsole":{"ServiceEnabled":true}}`, 1},
+		{testSystemID, `{"GraphicalConsole":{"ServiceEnabled":true}}`, 2},
+		{testSystemID, `{"GraphicalConsole":{}}`, 0},
+		{testSystemID, `{"GraphicalConsole":null}`, 0},
+		{testSystemID, `{}`, 0},
+		{testSystemID, `not-json`, 0},
+		{testSystemID, `{"GraphicalConsole":{"ServiceEnabled":"yes"}}`, 0},
+		{testUUIDNotFound, `{"GraphicalConsole":{"ServiceEnabled":true}}`, 0},
+		{"not-a-uuid", `{"GraphicalConsole":{"ServiceEnabled":true}}`, 0},
+		{"", `{"GraphicalConsole":{"ServiceEnabled":true}}`, 0},
+		{"/", `{"GraphicalConsole":{"ServiceEnabled":true}}`, 0},
+	}
+
+	for _, in := range seedInputs {
+		f.Add(in.systemID, in.body, in.errSel)
+	}
+
+	f.Fuzz(func(t *testing.T, systemID, body string, errSel uint8) {
+		repo := NewTestSystemsComputerSystemRepository()
+		repo.AddSystem(testSystemID, &redfishv1.ComputerSystem{ID: testSystemID, Name: "Test System"})
+
+		if injectedErr := kvmUpdateErrorFor(errSel); injectedErr != nil {
+			repo.errorOnUpdateKVM[testSystemID] = injectedErr
+		}
+
+		server := setupSystemActionsTestServer(repo)
+		router := disableRouterRedirects(setupPatchSystemTestRouter(server))
+
+		target := "/redfish/v1/Systems/" + url.PathEscape(systemID)
+		req := httptest.NewRequest(http.MethodPatch, target, bytes.NewBufferString(body))
+		req.Header.Set("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		router.ServeHTTP(w, req)
+
+		assertValidKVMActionStatus(t, w, systemID, body)
+	})
+}

--- a/redfish/internal/mocks/mock_repo.go
+++ b/redfish/internal/mocks/mock_repo.go
@@ -4,6 +4,7 @@ package mocks
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/device-management-toolkit/console/redfish/internal/controller/http/v1/generated"
 	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
@@ -12,7 +13,8 @@ import (
 
 // MockComputerSystemRepo implements ComputerSystemRepository with in-memory test data.
 type MockComputerSystemRepo struct {
-	systems map[string]*redfishv1.ComputerSystem
+	systems  map[string]*redfishv1.ComputerSystem
+	kvmState map[string]*mockKVMState
 }
 
 const (
@@ -25,6 +27,68 @@ const (
 	// State and health strings.
 	enabledState = "Enabled"
 	okHealth     = "OK"
+)
+
+// KVM consent demo state machine.
+//
+// The mock provisions systems in CCM (Client Control Mode), where Intel AMT
+// always requires user consent before a KVM session can start. The consent
+// flow is modeled as a deterministic state machine so demo mode
+// (REDFISH_USE_MOCK=true) can exercise every KVMStatus/UserConsentStatus
+// combination. The optInState values mirror IPS_OptInService.OptInState
+// reported by real Intel AMT hardware.
+//
+//	optInState        KVMStatus        UserConsentStatus
+//	---------------   --------------   -----------------
+//	NotStarted (0)    PendingConsent   Required
+//	Requested  (1)    PendingConsent   Requested
+//	Displayed  (2)    PendingConsent   Requested
+//	Received   (3)    Enabled          Granted
+//	InSession  (4)    Active           Granted
+//	Denied     (5)    Error            Denied
+//	Timeout    (6)    Error            Timeout
+const (
+	mockOptInNotStarted = 0
+	mockOptInRequested  = 1
+	mockOptInDisplayed  = 2
+	mockOptInReceived   = 3
+	mockOptInInSession  = 4
+	mockOptInDenied     = 5
+	mockOptInTimeout    = 6
+
+	mockControlModeACM = "ACM"
+	mockControlModeCCM = "CCM"
+
+	mockKVMConnectType       = "KVMIP"
+	mockKVMRedirectionPort   = 16994
+	mockKVMConsentCodeLength = 6
+
+	// KVMStatus values (mirror generated ComputerSystemOemIntelAMTKVMStatus).
+	mockKVMStatusActive         = "Active"
+	mockKVMStatusDisabled       = "Disabled"
+	mockKVMStatusEnabled        = "Enabled"
+	mockKVMStatusError          = "Error"
+	mockKVMStatusPendingConsent = "PendingConsent"
+
+	// UserConsentStatus values (mirror generated ComputerSystemOemIntelAMTUserConsentStatus).
+	mockUserConsentDenied      = "Denied"
+	mockUserConsentGranted     = "Granted"
+	mockUserConsentNotRequired = "NotRequired"
+	mockUserConsentRequested   = "Requested"
+	mockUserConsentRequired    = "Required"
+	mockUserConsentTimeout     = "Timeout"
+
+	// Demo consent codes recognized by SubmitKVMConsentCode so the UI/demo can
+	// deterministically reach the granted, denied, and timeout outcomes.
+	mockConsentCodeGranted = "123456"
+	mockConsentCodeDenied  = "000000"
+	mockConsentCodeTimeout = "111111"
+
+	mockConsentOperationSubmit = "SubmitKVMConsentCode"
+
+	// Consent ReturnValues mirror the values used by the real WSMAN repository.
+	mockConsentReturnInvalidState = 2
+	mockConsentReturnCodeInvalid  = 2066
 )
 
 // float32Ptr creates a pointer to a float32 value.
@@ -45,7 +109,8 @@ func stringPtr(s string) *string {
 // NewMockComputerSystemRepo creates a new mock repository with sample test data.
 func NewMockComputerSystemRepo() *MockComputerSystemRepo {
 	repo := &MockComputerSystemRepo{
-		systems: make(map[string]*redfishv1.ComputerSystem),
+		systems:  make(map[string]*redfishv1.ComputerSystem),
+		kvmState: make(map[string]*mockKVMState),
 	}
 
 	// Add default test system
@@ -88,6 +153,7 @@ func NewMockComputerSystemRepo() *MockComputerSystemRepo {
 	}
 
 	repo.systems["550e8400-e29b-41d4-a716-446655440001"] = testSystem
+	repo.kvmState[testSystem.ID] = newMockKVMState()
 
 	return repo
 }
@@ -111,6 +177,10 @@ func (r *MockComputerSystemRepo) GetByID(_ context.Context, systemID string) (*r
 
 	// Return a copy to prevent external modifications
 	systemCopy := *system
+
+	// Populate the GraphicalConsole from the current KVM state so that reads
+	// reflect the latest consent-flow transitions in demo mode.
+	systemCopy.GraphicalConsole = r.kvmStateFor(systemID).buildGraphicalConsole()
 
 	return &systemCopy, nil
 }
@@ -162,11 +232,16 @@ func (r *MockComputerSystemRepo) validatePowerStateTransition(current, target re
 // AddSystem adds a new system to the mock repository (for testing).
 func (r *MockComputerSystemRepo) AddSystem(system *redfishv1.ComputerSystem) {
 	r.systems[system.ID] = system
+
+	if _, ok := r.kvmState[system.ID]; !ok {
+		r.kvmState[system.ID] = newMockKVMState()
+	}
 }
 
 // RemoveSystem removes a system from the mock repository (for testing).
 func (r *MockComputerSystemRepo) RemoveSystem(systemID string) {
 	delete(r.systems, systemID)
+	delete(r.kvmState, systemID)
 }
 
 // GetBootSettings retrieves the current boot configuration for a system (mock implementation).
@@ -212,16 +287,11 @@ func (r *MockComputerSystemRepo) UpdateBootSettings(_ context.Context, systemID 
 
 // UpdateGraphicalConsoleServiceEnabled updates the mock KVM service enabled state for a system.
 func (r *MockComputerSystemRepo) UpdateGraphicalConsoleServiceEnabled(_ context.Context, systemID string, enabled bool) error {
-	system, exists := r.systems[systemID]
-	if !exists {
+	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
-	if system.GraphicalConsole == nil {
-		system.GraphicalConsole = &redfishv1.ComputerSystemHostGraphicalConsole{}
-	}
-
-	system.GraphicalConsole.ServiceEnabled = &enabled
+	r.kvmStateFor(systemID).enableKVM = enabled
 
 	return nil
 }
@@ -246,29 +316,196 @@ func (r *MockComputerSystemRepo) UpdateSerialConsoleServiceEnabled(_ context.Con
 	return nil
 }
 
-// RequestKVMConsent starts a mock KVM consent flow for an existing system.
+// RequestKVMConsent starts a mock KVM consent flow for an existing system,
+// transitioning the consent state to "Requested".
 func (r *MockComputerSystemRepo) RequestKVMConsent(_ context.Context, systemID string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
+	state := r.kvmStateFor(systemID)
+	if strings.EqualFold(strings.TrimSpace(state.controlMode), mockControlModeACM) {
+		return usecase.ErrKVMConsentNotRequiredInACM
+	}
+
+	state.optInState = mockOptInRequested
+
 	return nil
 }
 
-// SubmitKVMConsentCode accepts a mock six-digit consent code for an existing system.
-func (r *MockComputerSystemRepo) SubmitKVMConsentCode(_ context.Context, systemID, _ string) error {
+// SubmitKVMConsentCode accepts a mock six-digit consent code for an existing
+// system and transitions the consent state based on the code submitted.
+func (r *MockComputerSystemRepo) SubmitKVMConsentCode(_ context.Context, systemID, code string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
-	return nil
+	if !isSixDigitConsentCode(code) {
+		return usecase.ErrInvalidConsentCode
+	}
+
+	state := r.kvmStateFor(systemID)
+
+	// A consent code can only be submitted while a prompt is active.
+	if state.optInState != mockOptInRequested && state.optInState != mockOptInDisplayed {
+		return &usecase.ConsentFailedError{Operation: mockConsentOperationSubmit, ReturnValue: mockConsentReturnInvalidState}
+	}
+
+	if code == mockConsentCodeGranted {
+		state.optInState = mockOptInReceived
+
+		return nil
+	}
+
+	// Demo trigger codes drive the denied/timeout outcomes; any other code is
+	// treated as an incorrect entry and leaves the prompt active for retry.
+	switch code {
+	case mockConsentCodeDenied:
+		state.optInState = mockOptInDenied
+	case mockConsentCodeTimeout:
+		state.optInState = mockOptInTimeout
+	}
+
+	return &usecase.ConsentFailedError{Operation: mockConsentOperationSubmit, ReturnValue: mockConsentReturnCodeInvalid}
 }
 
-// CancelKVMConsent cancels a mock KVM consent flow for an existing system.
+// CancelKVMConsent cancels a mock KVM consent flow for an existing system,
+// resetting the consent state back to "Required".
 func (r *MockComputerSystemRepo) CancelKVMConsent(_ context.Context, systemID string) error {
 	if _, exists := r.systems[systemID]; !exists {
 		return usecase.ErrSystemNotFound
 	}
 
+	r.kvmStateFor(systemID).optInState = mockOptInNotStarted
+
 	return nil
+}
+
+// mockKVMState captures the per-system Intel AMT KVM runtime state used to build
+// a realistic GraphicalConsole resource in demo mode.
+type mockKVMState struct {
+	enableKVM    bool
+	kvmAvailable bool
+	controlMode  string
+	optInState   int
+}
+
+// newMockKVMState returns the default KVM state for a freshly provisioned mock
+// system: KVM available and enabled, CCM control mode, consent not yet started.
+func newMockKVMState() *mockKVMState {
+	return &mockKVMState{
+		enableKVM:    true,
+		kvmAvailable: true,
+		controlMode:  mockControlModeCCM,
+		optInState:   mockOptInNotStarted,
+	}
+}
+
+// kvmStateFor returns the KVM state for systemID, lazily creating a default
+// state for systems added without explicit KVM configuration.
+func (r *MockComputerSystemRepo) kvmStateFor(systemID string) *mockKVMState {
+	state, ok := r.kvmState[systemID]
+	if !ok {
+		state = newMockKVMState()
+		r.kvmState[systemID] = state
+	}
+
+	return state
+}
+
+// kvmStatus derives the Intel AMT KVMStatus from the current state, mirroring
+// usecase.determineKVMStatus.
+func (s *mockKVMState) kvmStatus() string {
+	if !s.kvmAvailable || !s.enableKVM {
+		return mockKVMStatusDisabled
+	}
+
+	if strings.EqualFold(strings.TrimSpace(s.controlMode), mockControlModeACM) {
+		if s.optInState == mockOptInInSession {
+			return mockKVMStatusActive
+		}
+
+		return mockKVMStatusEnabled
+	}
+
+	switch s.optInState {
+	case mockOptInInSession:
+		return mockKVMStatusActive
+	case mockOptInNotStarted, mockOptInRequested, mockOptInDisplayed:
+		return mockKVMStatusPendingConsent
+	case mockOptInReceived:
+		return mockKVMStatusEnabled
+	default:
+		return mockKVMStatusError
+	}
+}
+
+// userConsentStatus derives the Intel AMT UserConsentStatus from the current
+// state, mirroring usecase.determineKVMUserConsentStatus.
+func (s *mockKVMState) userConsentStatus() string {
+	if strings.EqualFold(strings.TrimSpace(s.controlMode), mockControlModeACM) {
+		return mockUserConsentNotRequired
+	}
+
+	switch s.optInState {
+	case mockOptInNotStarted:
+		return mockUserConsentRequired
+	case mockOptInRequested, mockOptInDisplayed:
+		return mockUserConsentRequested
+	case mockOptInReceived, mockOptInInSession:
+		return mockUserConsentGranted
+	case mockOptInDenied:
+		return mockUserConsentDenied
+	case mockOptInTimeout:
+		return mockUserConsentTimeout
+	default:
+		return mockUserConsentRequested
+	}
+}
+
+// buildGraphicalConsole constructs a GraphicalConsole resource reflecting the
+// current KVM state, mirroring the real WSMAN repository output.
+func (s *mockKVMState) buildGraphicalConsole() *redfishv1.ComputerSystemHostGraphicalConsole {
+	serviceEnabled := s.enableKVM
+
+	var connectTypes []string
+
+	var port *int64
+
+	if s.kvmAvailable {
+		connectTypes = []string{mockKVMConnectType}
+		redirectionPort := int64(mockKVMRedirectionPort)
+		port = &redirectionPort
+	}
+
+	return &redfishv1.ComputerSystemHostGraphicalConsole{
+		ConnectTypesSupported: connectTypes,
+		Port:                  port,
+		ServiceEnabled:        &serviceEnabled,
+		OEM: &redfishv1.ComputerSystemHostGraphicalConsoleOEM{
+			Intel: &redfishv1.ComputerSystemHostGraphicalConsoleIntel{
+				AMT: &redfishv1.ComputerSystemHostGraphicalConsoleAMT{
+					ControlMode:       s.controlMode,
+					KVMStatus:         s.kvmStatus(),
+					UserConsentStatus: s.userConsentStatus(),
+				},
+			},
+		},
+	}
+}
+
+// isSixDigitConsentCode reports whether code is exactly six numeric digits,
+// mirroring the validation performed by the real WSMAN repository.
+func isSixDigitConsentCode(code string) bool {
+	if len(code) != mockKVMConsentCodeLength {
+		return false
+	}
+
+	for _, c := range code {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+
+	return true
 }

--- a/redfish/internal/mocks/mock_repo_test.go
+++ b/redfish/internal/mocks/mock_repo_test.go
@@ -1,0 +1,472 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	redfishv1 "github.com/device-management-toolkit/console/redfish/internal/entity/v1"
+	"github.com/device-management-toolkit/console/redfish/internal/usecase"
+)
+
+const (
+	testMockSystemID      = "550e8400-e29b-41d4-a716-446655440001"
+	testMockUnknownSystem = "11111111-1111-1111-1111-111111111111"
+)
+
+// amtStatusFor reads the default mock system through the public repository API
+// and returns its Intel AMT graphical-console status, failing the test if it is
+// not populated.
+func amtStatusFor(t *testing.T, repo *MockComputerSystemRepo) *redfishv1.ComputerSystemHostGraphicalConsoleAMT {
+	t.Helper()
+
+	system, err := repo.GetByID(context.Background(), testMockSystemID)
+	if err != nil {
+		t.Fatalf("GetByID(%q) returned error: %v", testMockSystemID, err)
+	}
+
+	if system.GraphicalConsole == nil || system.GraphicalConsole.OEM == nil ||
+		system.GraphicalConsole.OEM.Intel == nil || system.GraphicalConsole.OEM.Intel.AMT == nil {
+		t.Fatalf("GetByID(%q) did not populate GraphicalConsole AMT status", testMockSystemID)
+	}
+
+	return system.GraphicalConsole.OEM.Intel.AMT
+}
+
+func TestNewMockComputerSystemRepoInitialKVMState(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+
+	system, err := repo.GetByID(context.Background(), testMockSystemID)
+	if err != nil {
+		t.Fatalf("GetByID returned error: %v", err)
+	}
+
+	console := system.GraphicalConsole
+	if console == nil {
+		t.Fatal("expected GraphicalConsole to be populated")
+	}
+
+	if console.ServiceEnabled == nil || !*console.ServiceEnabled {
+		t.Fatalf("expected ServiceEnabled=true, got %#v", console.ServiceEnabled)
+	}
+
+	if console.Port == nil || *console.Port != mockKVMRedirectionPort {
+		t.Fatalf("expected Port=%d, got %#v", mockKVMRedirectionPort, console.Port)
+	}
+
+	if len(console.ConnectTypesSupported) != 1 || console.ConnectTypesSupported[0] != mockKVMConnectType {
+		t.Fatalf("expected ConnectTypesSupported=[%q], got %#v", mockKVMConnectType, console.ConnectTypesSupported)
+	}
+
+	amt := console.OEM.Intel.AMT
+	if amt.ControlMode != mockControlModeCCM {
+		t.Fatalf("expected ControlMode=%q, got %q", mockControlModeCCM, amt.ControlMode)
+	}
+
+	if amt.KVMStatus != mockKVMStatusPendingConsent {
+		t.Fatalf("expected initial KVMStatus=%q, got %q", mockKVMStatusPendingConsent, amt.KVMStatus)
+	}
+
+	if amt.UserConsentStatus != mockUserConsentRequired {
+		t.Fatalf("expected initial UserConsentStatus=%q, got %q", mockUserConsentRequired, amt.UserConsentStatus)
+	}
+}
+
+func TestMockKVMConsentLifecycleGranted(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+	ctx := context.Background()
+
+	// Request consent -> Requested / PendingConsent.
+	if err := repo.RequestKVMConsent(ctx, testMockSystemID); err != nil {
+		t.Fatalf("RequestKVMConsent returned error: %v", err)
+	}
+
+	amt := amtStatusFor(t, repo)
+	if amt.UserConsentStatus != mockUserConsentRequested || amt.KVMStatus != mockKVMStatusPendingConsent {
+		t.Fatalf("after request: got (KVMStatus=%q, UserConsentStatus=%q)", amt.KVMStatus, amt.UserConsentStatus)
+	}
+
+	// Submit the correct demo code -> Granted / Enabled.
+	if err := repo.SubmitKVMConsentCode(ctx, testMockSystemID, mockConsentCodeGranted); err != nil {
+		t.Fatalf("SubmitKVMConsentCode returned error: %v", err)
+	}
+
+	amt = amtStatusFor(t, repo)
+	if amt.UserConsentStatus != mockUserConsentGranted || amt.KVMStatus != mockKVMStatusEnabled {
+		t.Fatalf("after grant: got (KVMStatus=%q, UserConsentStatus=%q)", amt.KVMStatus, amt.UserConsentStatus)
+	}
+
+	// Cancel consent -> Required / PendingConsent.
+	if err := repo.CancelKVMConsent(ctx, testMockSystemID); err != nil {
+		t.Fatalf("CancelKVMConsent returned error: %v", err)
+	}
+
+	amt = amtStatusFor(t, repo)
+	if amt.UserConsentStatus != mockUserConsentRequired || amt.KVMStatus != mockKVMStatusPendingConsent {
+		t.Fatalf("after cancel: got (KVMStatus=%q, UserConsentStatus=%q)", amt.KVMStatus, amt.UserConsentStatus)
+	}
+}
+
+func TestMockSubmitKVMConsentCodeOutcomes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		code            string
+		wantReturnValue int
+		wantKVMStatus   string
+		wantUserConsent string
+	}{
+		{
+			name:            "denied demo code",
+			code:            mockConsentCodeDenied,
+			wantReturnValue: mockConsentReturnCodeInvalid,
+			wantKVMStatus:   mockKVMStatusError,
+			wantUserConsent: mockUserConsentDenied,
+		},
+		{
+			name:            "timeout demo code",
+			code:            mockConsentCodeTimeout,
+			wantReturnValue: mockConsentReturnCodeInvalid,
+			wantKVMStatus:   mockKVMStatusError,
+			wantUserConsent: mockUserConsentTimeout,
+		},
+		{
+			name:            "incorrect code keeps prompt active",
+			code:            "654321",
+			wantReturnValue: mockConsentReturnCodeInvalid,
+			wantKVMStatus:   mockKVMStatusPendingConsent,
+			wantUserConsent: mockUserConsentRequested,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := NewMockComputerSystemRepo()
+			ctx := context.Background()
+
+			if err := repo.RequestKVMConsent(ctx, testMockSystemID); err != nil {
+				t.Fatalf("RequestKVMConsent returned error: %v", err)
+			}
+
+			err := repo.SubmitKVMConsentCode(ctx, testMockSystemID, tt.code)
+
+			var consentErr *usecase.ConsentFailedError
+			if !errors.As(err, &consentErr) {
+				t.Fatalf("expected *usecase.ConsentFailedError, got %v", err)
+			}
+
+			if consentErr.ReturnValue != tt.wantReturnValue {
+				t.Fatalf("expected ReturnValue=%d, got %d", tt.wantReturnValue, consentErr.ReturnValue)
+			}
+
+			amt := amtStatusFor(t, repo)
+			if amt.KVMStatus != tt.wantKVMStatus || amt.UserConsentStatus != tt.wantUserConsent {
+				t.Fatalf("got (KVMStatus=%q, UserConsentStatus=%q), want (%q, %q)",
+					amt.KVMStatus, amt.UserConsentStatus, tt.wantKVMStatus, tt.wantUserConsent)
+			}
+		})
+	}
+}
+
+func TestMockSubmitKVMConsentCodeInvalidFormat(t *testing.T) {
+	t.Parallel()
+
+	invalidCodes := []string{"", "12345", "1234567", "abcdef", "12 456", "１２３４５６"}
+
+	for _, code := range invalidCodes {
+		code := code
+
+		t.Run("code="+code, func(t *testing.T) {
+			t.Parallel()
+
+			repo := NewMockComputerSystemRepo()
+			ctx := context.Background()
+
+			if err := repo.RequestKVMConsent(ctx, testMockSystemID); err != nil {
+				t.Fatalf("RequestKVMConsent returned error: %v", err)
+			}
+
+			err := repo.SubmitKVMConsentCode(ctx, testMockSystemID, code)
+			if !errors.Is(err, usecase.ErrInvalidConsentCode) {
+				t.Fatalf("expected ErrInvalidConsentCode for %q, got %v", code, err)
+			}
+		})
+	}
+}
+
+func TestMockSubmitKVMConsentCodeRequiresActivePrompt(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+	ctx := context.Background()
+
+	// No RequestKVMConsent call: the opt-in flow has not started.
+	err := repo.SubmitKVMConsentCode(ctx, testMockSystemID, mockConsentCodeGranted)
+
+	var consentErr *usecase.ConsentFailedError
+	if !errors.As(err, &consentErr) {
+		t.Fatalf("expected *usecase.ConsentFailedError, got %v", err)
+	}
+
+	if consentErr.ReturnValue != mockConsentReturnInvalidState {
+		t.Fatalf("expected ReturnValue=%d, got %d", mockConsentReturnInvalidState, consentErr.ReturnValue)
+	}
+}
+
+func TestMockKVMConsentSystemNotFound(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		call func(repo *MockComputerSystemRepo) error
+	}{
+		{
+			name: "RequestKVMConsent",
+			call: func(repo *MockComputerSystemRepo) error {
+				return repo.RequestKVMConsent(context.Background(), testMockUnknownSystem)
+			},
+		},
+		{
+			name: "SubmitKVMConsentCode",
+			call: func(repo *MockComputerSystemRepo) error {
+				return repo.SubmitKVMConsentCode(context.Background(), testMockUnknownSystem, mockConsentCodeGranted)
+			},
+		},
+		{
+			name: "CancelKVMConsent",
+			call: func(repo *MockComputerSystemRepo) error {
+				return repo.CancelKVMConsent(context.Background(), testMockUnknownSystem)
+			},
+		},
+		{
+			name: "UpdateGraphicalConsoleServiceEnabled",
+			call: func(repo *MockComputerSystemRepo) error {
+				return repo.UpdateGraphicalConsoleServiceEnabled(context.Background(), testMockUnknownSystem, true)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			repo := NewMockComputerSystemRepo()
+			if err := tt.call(repo); !errors.Is(err, usecase.ErrSystemNotFound) {
+				t.Fatalf("expected ErrSystemNotFound, got %v", err)
+			}
+		})
+	}
+}
+
+func TestMockUpdateGraphicalConsoleServiceEnabledStatus(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+	ctx := context.Background()
+
+	// Disabling KVM forces KVMStatus to Disabled while leaving the consent
+	// status intact.
+	if err := repo.UpdateGraphicalConsoleServiceEnabled(ctx, testMockSystemID, false); err != nil {
+		t.Fatalf("UpdateGraphicalConsoleServiceEnabled(false) returned error: %v", err)
+	}
+
+	amt := amtStatusFor(t, repo)
+	if amt.KVMStatus != mockKVMStatusDisabled {
+		t.Fatalf("expected KVMStatus=%q after disable, got %q", mockKVMStatusDisabled, amt.KVMStatus)
+	}
+
+	// Re-enabling restores the consent-driven status.
+	if err := repo.UpdateGraphicalConsoleServiceEnabled(ctx, testMockSystemID, true); err != nil {
+		t.Fatalf("UpdateGraphicalConsoleServiceEnabled(true) returned error: %v", err)
+	}
+
+	amt = amtStatusFor(t, repo)
+	if amt.KVMStatus != mockKVMStatusPendingConsent {
+		t.Fatalf("expected KVMStatus=%q after re-enable, got %q", mockKVMStatusPendingConsent, amt.KVMStatus)
+	}
+}
+
+func TestMockRequestKVMConsentACM(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+	repo.kvmStateFor(testMockSystemID).controlMode = mockControlModeACM
+
+	err := repo.RequestKVMConsent(context.Background(), testMockSystemID)
+	if !errors.Is(err, usecase.ErrKVMConsentNotRequiredInACM) {
+		t.Fatalf("expected ErrKVMConsentNotRequiredInACM, got %v", err)
+	}
+
+	amt := amtStatusFor(t, repo)
+	if amt.UserConsentStatus != mockUserConsentNotRequired {
+		t.Fatalf("expected UserConsentStatus=%q in ACM, got %q", mockUserConsentNotRequired, amt.UserConsentStatus)
+	}
+
+	if amt.KVMStatus != mockKVMStatusEnabled {
+		t.Fatalf("expected KVMStatus=%q in ACM, got %q", mockKVMStatusEnabled, amt.KVMStatus)
+	}
+}
+
+func TestMockKVMStateStatusMapping(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		state           mockKVMState
+		wantKVMStatus   string
+		wantUserConsent string
+	}{
+		{
+			name:            "CCM not started",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInNotStarted},
+			wantKVMStatus:   mockKVMStatusPendingConsent,
+			wantUserConsent: mockUserConsentRequired,
+		},
+		{
+			name:            "CCM requested",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInRequested},
+			wantKVMStatus:   mockKVMStatusPendingConsent,
+			wantUserConsent: mockUserConsentRequested,
+		},
+		{
+			name:            "CCM displayed",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInDisplayed},
+			wantKVMStatus:   mockKVMStatusPendingConsent,
+			wantUserConsent: mockUserConsentRequested,
+		},
+		{
+			name:            "CCM received",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInReceived},
+			wantKVMStatus:   mockKVMStatusEnabled,
+			wantUserConsent: mockUserConsentGranted,
+		},
+		{
+			name:            "CCM in session",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInInSession},
+			wantKVMStatus:   mockKVMStatusActive,
+			wantUserConsent: mockUserConsentGranted,
+		},
+		{
+			name:            "CCM denied",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInDenied},
+			wantKVMStatus:   mockKVMStatusError,
+			wantUserConsent: mockUserConsentDenied,
+		},
+		{
+			name:            "CCM timeout",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInTimeout},
+			wantKVMStatus:   mockKVMStatusError,
+			wantUserConsent: mockUserConsentTimeout,
+		},
+		{
+			name:            "KVM unavailable",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: false, controlMode: mockControlModeCCM, optInState: mockOptInNotStarted},
+			wantKVMStatus:   mockKVMStatusDisabled,
+			wantUserConsent: mockUserConsentRequired,
+		},
+		{
+			name:            "KVM disabled",
+			state:           mockKVMState{enableKVM: false, kvmAvailable: true, controlMode: mockControlModeCCM, optInState: mockOptInReceived},
+			wantKVMStatus:   mockKVMStatusDisabled,
+			wantUserConsent: mockUserConsentGranted,
+		},
+		{
+			name:            "ACM not started",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeACM, optInState: mockOptInNotStarted},
+			wantKVMStatus:   mockKVMStatusEnabled,
+			wantUserConsent: mockUserConsentNotRequired,
+		},
+		{
+			name:            "ACM in session",
+			state:           mockKVMState{enableKVM: true, kvmAvailable: true, controlMode: mockControlModeACM, optInState: mockOptInInSession},
+			wantKVMStatus:   mockKVMStatusActive,
+			wantUserConsent: mockUserConsentNotRequired,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := tt.state
+			if got := state.kvmStatus(); got != tt.wantKVMStatus {
+				t.Fatalf("kvmStatus() = %q, want %q", got, tt.wantKVMStatus)
+			}
+
+			if got := state.userConsentStatus(); got != tt.wantUserConsent {
+				t.Fatalf("userConsentStatus() = %q, want %q", got, tt.wantUserConsent)
+			}
+		})
+	}
+}
+
+func TestMockKVMStateUnknownOptInState(t *testing.T) {
+	t.Parallel()
+
+	// An opt-in state outside the documented 0..6 range must fall back to the
+	// defensive Error / Requested defaults rather than panicking.
+	const unknownOptInState = 99
+
+	state := mockKVMState{
+		enableKVM:    true,
+		kvmAvailable: true,
+		controlMode:  mockControlModeCCM,
+		optInState:   unknownOptInState,
+	}
+
+	if got := state.kvmStatus(); got != mockKVMStatusError {
+		t.Fatalf("kvmStatus() = %q, want %q", got, mockKVMStatusError)
+	}
+
+	if got := state.userConsentStatus(); got != mockUserConsentRequested {
+		t.Fatalf("userConsentStatus() = %q, want %q", got, mockUserConsentRequested)
+	}
+}
+
+func TestMockKVMStateForLazilyCreatesDefault(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+
+	// Simulate a system that exists without an explicit KVM entry to exercise
+	// the lazy default-state creation in kvmStateFor.
+	delete(repo.kvmState, testMockSystemID)
+
+	state := repo.kvmStateFor(testMockSystemID)
+	if state == nil {
+		t.Fatal("kvmStateFor returned nil for a system without explicit KVM state")
+	}
+
+	// The lazily created default must be persisted for stable subsequent reads.
+	if _, ok := repo.kvmState[testMockSystemID]; !ok {
+		t.Fatal("kvmStateFor did not persist the lazily created default state")
+	}
+
+	if !state.enableKVM || !state.kvmAvailable ||
+		state.controlMode != mockControlModeCCM || state.optInState != mockOptInNotStarted {
+		t.Fatalf("unexpected lazily created default state: %#v", state)
+	}
+}
+
+func TestMockGetByIDUnknownSystem(t *testing.T) {
+	t.Parallel()
+
+	repo := NewMockComputerSystemRepo()
+
+	if _, err := repo.GetByID(context.Background(), testMockUnknownSystem); !errors.Is(err, usecase.ErrSystemNotFound) {
+		t.Fatalf("expected ErrSystemNotFound, got %v", err)
+	}
+}

--- a/redfish/internal/usecase/computer_system_test.go
+++ b/redfish/internal/usecase/computer_system_test.go
@@ -3,6 +3,7 @@ package usecase
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -926,8 +927,16 @@ func assertDeviceLookupResult(t *testing.T, device *devicev1.Device, err, wantEr
 	}
 }
 
+// generateRedirectionTokenConfigMu serializes the two GenerateRedirectionToken
+// tests below, which mutate the shared config.ConsoleConfig global. Both remain
+// parallel (per the paralleltest/tparallel linters); the mutex prevents them from
+// clobbering each other's global state when run concurrently.
+var generateRedirectionTokenConfigMu sync.Mutex
+
 func TestGenerateRedirectionToken_UsesDeviceRepo(t *testing.T) {
 	t.Parallel()
+
+	generateRedirectionTokenConfigMu.Lock()
 
 	original := config.ConsoleConfig
 	config.ConsoleConfig = &config.Config{}
@@ -936,6 +945,7 @@ func TestGenerateRedirectionToken_UsesDeviceRepo(t *testing.T) {
 
 	t.Cleanup(func() {
 		config.ConsoleConfig = original
+		generateRedirectionTokenConfigMu.Unlock()
 	})
 
 	tests := []struct {
@@ -985,11 +995,14 @@ func assertGenerateTokenResult(t *testing.T, resp *generated.ComputerSystemOemIn
 func TestGenerateRedirectionToken_ConfigNotInitialized(t *testing.T) {
 	t.Parallel()
 
+	generateRedirectionTokenConfigMu.Lock()
+
 	original := config.ConsoleConfig
 	config.ConsoleConfig = nil
 
 	t.Cleanup(func() {
 		config.ConsoleConfig = original
+		generateRedirectionTokenConfigMu.Unlock()
 	})
 
 	uc := &ComputerSystemUseCase{DeviceRepo: testDeviceLookupRepo{}}


### PR DESCRIPTION
Add fuzz tests for KVM OEM consent endpoints and make the mock repo return stateful, realistic KVM status (request/submit/cancel) for demo mode.