### PR TITLE
ci: fix the OpenAPI change detection in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,6 +150,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+          fetch-depth: 2
   
       # Restore unified build cache
       - shell: bash
@@ -236,8 +237,7 @@ jobs:
       - name: Check if OpenAPI files changed
         id: check-openapi-changes
         run: |
-          git fetch origin main
-          if git diff --name-only origin/main HEAD | grep -q '^internal/controller/openapi/'; then
+          if git diff --name-only ${{ github.event.before }} ${{ github.sha }} | grep -q '^internal/controller/openapi/'; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else
             echo "changed=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Addresses: https://github.com/device-management-toolkit/console/issues/1080

**Issue Root cause:** The "Check if OpenAPI files changed" step ran after Semantic Release, which had already pushed a new release commit to origin/main. At that point git diff origin/main HEAD compared in the wrong direction showing the changelog/version bump files, not the OpenAPI changes from the merged PR so the grep never matched and changed=false detected and hence further steps were skipped.

**Fix:** 
- Changed diff to HEAD~1 HEAD which compares what actually changed in the triggering merge commit, independent of origin/main's state
- Added fetch-depth: 2 to the checkout so HEAD~1 is available in the shallow clone
- Removed the unnecessary git fetch origin main