### PR TITLE
fix: login Snackbar Shows Undefined for Invalid Credentials

### DIFF
--- a/internal/controller/httpapi/v1/error.go
+++ b/internal/controller/httpapi/v1/error.go
@@ -18,7 +18,11 @@ import (
 )
 
 // errorKey is the JSON field name used for error messages in gin.H responses.
-const errorKey = "error"
+// messageKey is the JSON field name used for human-readable messages in gin.H responses.
+const (
+	errorKey   = "error"
+	messageKey = "message"
+)
 
 type response struct {
 	Error   string `json:"error,omitempty" example:"message"`

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -76,7 +76,7 @@ func (lr LoginRoute) Login(c *gin.Context) {
 
 func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 	if creds.Username != lr.Config.AdminUsername || creds.Password != lr.Config.AdminPassword {
-		c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid credentials"})
+		c.JSON(http.StatusUnauthorized, response{Error: "invalid credentials", Message: "Incorrect username or password"})
 
 		return
 	}

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -76,7 +76,7 @@ func (lr LoginRoute) Login(c *gin.Context) {
 
 func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 	if creds.Username != lr.Config.AdminUsername || creds.Password != lr.Config.AdminPassword {
-		c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid credentials", messageKey: "Incorrect username or password"})
+		c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid credentials", messageKey: "Incorrect Username and/or Password!"})
 
 		return
 	}

--- a/internal/controller/httpapi/v1/login.go
+++ b/internal/controller/httpapi/v1/login.go
@@ -76,7 +76,7 @@ func (lr LoginRoute) Login(c *gin.Context) {
 
 func (lr LoginRoute) handleBasicAuth(creds dto.Credentials, c *gin.Context) {
 	if creds.Username != lr.Config.AdminUsername || creds.Password != lr.Config.AdminPassword {
-		c.JSON(http.StatusUnauthorized, response{Error: "invalid credentials", Message: "Incorrect username or password"})
+		c.JSON(http.StatusUnauthorized, gin.H{errorKey: "invalid credentials", messageKey: "Incorrect username or password"})
 
 		return
 	}

--- a/internal/controller/httpapi/v1/login_test.go
+++ b/internal/controller/httpapi/v1/login_test.go
@@ -1,15 +1,39 @@
 package v1
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/gin-gonic/gin"
 	"github.com/stretchr/testify/require"
 
 	"github.com/device-management-toolkit/console/config"
 )
+
+func TestLogin_InvalidCredentialsReturnsMessage(t *testing.T) {
+	t.Parallel()
+
+	engine := gin.New()
+	route := LoginRoute{Config: &config.Config{Auth: config.Auth{AdminUsername: "admin", AdminPassword: "secret"}}}
+	engine.POST("/api/v1/authorize", route.Login)
+
+	req, err := http.NewRequest(http.MethodPost, "/api/v1/authorize", bytes.NewBufferString(`{"username":"admin","password":"wrong"}`))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusUnauthorized, w.Code)
+
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
+	require.Equal(t, "invalid credentials", got["error"])
+	require.Equal(t, "Incorrect username or password", got["message"])
+}
 
 // oidcDiscoveryServer spins up a TLS test server that serves the minimum
 // OpenID Connect discovery document that go-oidc requires. The issuer field

--- a/internal/controller/httpapi/v1/login_test.go
+++ b/internal/controller/httpapi/v1/login_test.go
@@ -32,7 +32,7 @@ func TestLogin_InvalidCredentialsReturnsMessage(t *testing.T) {
 	var got map[string]string
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &got))
 	require.Equal(t, "invalid credentials", got["error"])
-	require.Equal(t, "Incorrect username or password", got["message"])
+	require.Equal(t, "Incorrect Username and/or Password!", got["message"])
 }
 
 // oidcDiscoveryServer spins up a TLS test server that serves the minimum

--- a/internal/controller/openapi/devices.go
+++ b/internal/controller/openapi/devices.go
@@ -22,7 +22,7 @@ func (f *FuegoAdapter) registerDeviceAuthRoutes() {
 		fuego.OptionTags("Devices"),
 		fuego.OptionSummary("Authorize"),
 		fuego.OptionDescription("Authenticate and return an access token"),
-		apiRouteOptions(),
+		fuego.OptionAddResponse(http.StatusUnauthorized, "Unauthorized: invalid credentials", fuego.Response{Type: ErrorResponse{}}),
 	)
 
 	fuego.Get(f.server, "/api/v1/authorize/redirection/{id}", f.loginRedirection,

--- a/internal/controller/openapi/responses.go
+++ b/internal/controller/openapi/responses.go
@@ -2,3 +2,9 @@ package openapi
 
 // NoContentResponse models endpoints that intentionally return HTTP 204.
 type NoContentResponse struct{}
+
+// ErrorResponse models error responses with error and message fields.
+type ErrorResponse struct {
+	Error   string `json:"error,omitempty" example:"invalid credentials"`
+	Message string `json:"message,omitempty" example:"Incorrect username or password"`
+}


### PR DESCRIPTION
**Description**
This PR fixes issue #994 where the login snackbar showed Undefined when invalid username/password was submitted.

**Problem**
When POST /api/v1/authorize returned 401 for bad credentials, the frontend expected a message field but did not receive a clear user-facing value, which resulted in an unclear snackbar message.

**Root Cause**
The invalid-credentials response did not include a user-friendly message aligned with frontend expectations.

**Expected behavior**
When the username or password is incorrect, the snackbar should show a clear message such as Incorrect username or password.

**Screenshots**
<img width="610" height="367" alt="undefined_login" src="https://github.com/user-attachments/assets/9cbf9101-c153-4ad3-bab7-52a26c17dfac" />

