### PR TITLE
feat: Enable Zizmor scan

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -43,7 +43,7 @@ jobs:
         run: |
           uvx zizmor=="$ZIZMOR_VERSION" \
             --format sarif \
-            "$GITHUB_WORKSPACE" \
+            .github \
             > zizmor_scan_report.sarif
 
       - name: Upload SARIF to GitHub Security

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+
+name: Zizmor Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    permissions:
+      contents: read
+      security-events: write
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run Zizmor scan
+        id: zizmor
+        uses: open-edge-platform/orch-ci/.github/actions/security/zizmor@587c67a41629ce30ddbc6e5f06c0990b13c4118c  # v2026.1.3
+        with:
+          output-format: sarif
+          upload-sarif: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,7 +34,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          token: ${{ secrets.SECURITY_TOKEN }}
           persist-credentials: false
 
       - name: Install uv
@@ -44,7 +43,7 @@ jobs:
         run: |
           uvx zizmor=="$ZIZMOR_VERSION" \
             --format sarif \
-            .github/workflows .github/actions \
+            "$GITHUB_WORKSPACE" \
             > zizmor_scan_report.sarif
 
       - name: Upload SARIF to GitHub Security

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        with:
+          enable-cache: false
 
       - name: Run Zizmor
         run: |
@@ -52,7 +54,7 @@ jobs:
           sarif_file: zizmor_scan_report.sarif
 
       - name: Upload Zizmor report artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: zizmor-results
           path: zizmor_scan_report.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -54,7 +54,7 @@ jobs:
           sarif_file: zizmor_scan_report.sarif
 
       - name: Upload Zizmor report artifact
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: zizmor-results
           path: zizmor_scan_report.sarif

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -22,6 +22,9 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    env:
+      ZIZMOR_VERSION: 1.20.0
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
@@ -33,11 +36,24 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Run Zizmor scan
-        id: zizmor
-        uses: open-edge-platform/orch-ci/.github/actions/security/zizmor@587c67a41629ce30ddbc6e5f06c0990b13c4118c  # v2026.1.3
+      - name: Install uv
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Run Zizmor
+        run: |
+          uvx zizmor=="$ZIZMOR_VERSION" \
+            --format sarif \
+            .github/workflows .github/actions \
+            > zizmor_scan_report.sarif
+
+      - name: Upload SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         with:
-          scan-scope: all
-          paths: .
-          output-format: sarif
-          upload-sarif: true
+          sarif_file: zizmor_scan_report.sarif
+
+      - name: Upload Zizmor report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: zizmor-results
+          path: zizmor_scan_report.sarif
+          retention-days: 7

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,5 +37,7 @@ jobs:
         id: zizmor
         uses: open-edge-platform/orch-ci/.github/actions/security/zizmor@587c67a41629ce30ddbc6e5f06c0990b13c4118c  # v2026.1.3
         with:
+          scan-scope: all
+          paths: .
           output-format: sarif
           upload-sarif: true

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
+          token: ${{ secrets.SECURITY_TOKEN }}
           persist-credentials: false
 
       - name: Install uv


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for automated security scanning using Zizmor. The workflow is triggered on pushes and pull requests to the `main` branch, as well as via manual dispatch. It includes steps for hardening the runner, checking out the code, and running the Zizmor security scan.

**New Zizmor Security Scan Workflow:**
Jira: https://jira.devtools.intel.com/browse/NEXUIE-133056

* Added `.github/workflows/zizmor.yml` to automate security scanning with Zizmor on code pushes, pull requests, and manual triggers. The workflow includes runner hardening, code checkout, and uploads scan results in SARIF format for security event reporting.