### PR TITLE
fix(api): use startIndex variable in downloadEventLog pagination loop

### DIFF
--- a/internal/controller/httpapi/v1/auditlog.go
+++ b/internal/controller/httpapi/v1/auditlog.go
@@ -12,6 +12,10 @@ import (
 	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
 )
 
+const (
+	eventLogBatchSize = 100
+)
+
 func (r *deviceManagementRoutes) getAuditLog(c *gin.Context) {
 	guid := c.Param("guid")
 
@@ -110,9 +114,9 @@ func (r *deviceManagementRoutes) downloadEventLog(c *gin.Context) {
 
 	startIndex := 0
 
-	// Keep fetching logs until NoMoreRecords is true
+	// Keep fetching logs until there are no more records.
 	for {
-		eventLogs, err := r.d.GetEventLog(c.Request.Context(), 0, 0, guid)
+		eventLogs, err := r.d.GetEventLog(c.Request.Context(), startIndex, eventLogBatchSize, guid)
 		if err != nil {
 			r.l.Error(err, "http - v1 - getEventLog")
 			ErrorResponse(c, err)
@@ -123,8 +127,8 @@ func (r *deviceManagementRoutes) downloadEventLog(c *gin.Context) {
 		// Append the current batch of logs
 		allEventLogs = append(allEventLogs, eventLogs.Records...)
 
-		// Break if no more records
-		if eventLogs.HasMoreRecords {
+		// Break when no more records are available from AMT.
+		if !eventLogs.HasMoreRecords {
 			break
 		}
 

--- a/internal/controller/httpapi/v1/auditlog_test.go
+++ b/internal/controller/httpapi/v1/auditlog_test.go
@@ -1,0 +1,64 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/device-management-toolkit/console/internal/entity/dto/v1"
+	"github.com/device-management-toolkit/console/internal/mocks"
+	"github.com/device-management-toolkit/console/pkg/logger"
+)
+
+func TestDownloadEventLogPaginatesWithStartIndex(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	log := logger.New("error")
+	deviceManagement := mocks.NewMockDeviceManagementFeature(ctrl)
+	amtExplorer := mocks.NewMockAMTExplorerFeature(ctrl)
+	exporter := mocks.NewMockExporter(ctrl)
+
+	engine := gin.New()
+	handler := engine.Group("/api/v1")
+	NewAmtRoutes(handler, deviceManagement, amtExplorer, exporter, log)
+
+	firstBatch := dto.EventLogs{
+		Records: []dto.EventLog{
+			{Time: "t1", Entity: "BIOS", EventSeverity: "Monitor", Description: "first"},
+			{Time: "t2", Entity: "BIOS", EventSeverity: "Monitor", Description: "second"},
+		},
+		HasMoreRecords: true,
+	}
+
+	secondBatch := dto.EventLogs{
+		Records: []dto.EventLog{
+			{Time: "t3", Entity: "Intel(r) ME", EventSeverity: "Monitor", Description: "third"},
+		},
+		HasMoreRecords: false,
+	}
+
+	deviceManagement.EXPECT().GetEventLog(context.Background(), 0, eventLogBatchSize, "valid-guid").Return(firstBatch, nil)
+	deviceManagement.EXPECT().GetEventLog(context.Background(), 2, eventLogBatchSize, "valid-guid").Return(secondBatch, nil)
+
+	expectedLogs := append(append([]dto.EventLog{}, firstBatch.Records...), secondBatch.Records...)
+	exporter.EXPECT().ExportEventLogsCSV(expectedLogs).Return(strings.NewReader("Time,Source,Event Severity,Description\n"), nil)
+
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/api/v1/amt/log/event/valid-guid/download", http.NoBody)
+	require.NoError(t, err)
+
+	w := httptest.NewRecorder()
+	engine.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	require.Contains(t, w.Header().Get("Content-Type"), "text/csv")
+	require.Equal(t, "Time,Source,Event Severity,Description\n", w.Body.String())
+}


### PR DESCRIPTION
The function calculated and updated startIndex but passed 0 to GetEventLog, breaking pagination. Now passes startIndex and eventLogBatchSize properly.

Fixes #1104

## Manual Testing

### Setup
1. Activate the AMT device first
2. Set environment variables:

```
GUID="<GUID>"
TOKEN=$(curl -sk https://localhost:8181/api/v1/authorize \
  -H "Content-Type: application/json" \
  -d '{"username":"<username>","password":"<password>"}' | jq -r '.token')
```

### Test Pagination API

Check event logs (page 1 - 5 records):

```
curl -sk "https://localhost:8181/api/v1/amt/log/event/$GUID?\$top=5&\$skip=0" \
  -H "Authorization: Bearer $TOKEN" | jq
```

Check event logs (page 2 - next 5 records):

```
curl -sk "https://localhost:8181/api/v1/amt/log/event/$GUID?\$top=5&\$skip=5" \
  -H "Authorization: Bearer $TOKEN" | jq
```

### Generate More Events

Trigger power cycle to generate new event logs:

Trigger power action to generate likely AMT events (PowerCycle = 5)

```
curl -sk -X POST "https://localhost:8181/api/v1/amt/power/action/$GUID" \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{"action":5}' | jq
```

### Verified API pagination works:

```
curl -sk "https://localhost:8181/api/v1/amt/log/event/$GUID?\$top=10&\$skip=0" \
  -H "Authorization: Bearer $TOKEN" | jq
```

### Test Download (Fixed Endpoint)
Download all event logs via CSV:

You can manually download the csv file from UI or
Downloaded event logs via fixed endpoint:

```
curl -sk -o event_logs.csv \
  "https://localhost:8181/api/v1/amt/log/event/$GUID/download" \
  -H "Authorization: Bearer $TOKEN"
```

Verify download contains all events:

```
wc -l event_logs.csv
head -n 20 event_logs.csv
```

### Output:

Successfully downloaded 18 event logs from multiple boot cycles (timestamps show events from 08:57 and 09:36)
19 lines (18 events + 1 header)

```
wc -l event_logs.csv
19 event_logs.csv

head -n 20 event_logs.csv
Time,Source,Event Severity,Description
2026-07-06 09:36:41 +0530 IST,BIOS,Non-critical condition,Starting operating system boot process
2026-07-06 09:36:42 +0530 IST,Intel(r) ME,Monitor,Embedded controller/management controller initialization
2026-07-06 09:36:35 +0530 IST,BIOS,Monitor,USB resource configuration
2026-07-06 09:36:35 +0530 IST,BIOS,Monitor,USB resource configuration
2026-07-06 09:36:34 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 09:36:34 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 09:36:34 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 09:36:34 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 09:36:34 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 08:57:28 +0530 IST,BIOS,Non-critical condition,Starting operating system boot process
2026-07-06 08:57:27 +0530 IST,Intel(r) ME,Monitor,Embedded controller/management controller initialization
2026-07-06 08:57:20 +0530 IST,BIOS,Monitor,USB resource configuration
2026-07-06 08:57:20 +0530 IST,BIOS,Monitor,USB resource configuration
2026-07-06 08:57:20 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 08:57:20 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 08:57:20 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 08:57:19 +0530 IST,BIOS,Monitor,PCI resource configuration
2026-07-06 08:57:19 +0530 IST,BIOS,Monitor,PCI resource configuration
```