### PR TITLE
ci(gh-actions): resolve zizmor findings

### DIFF
--- a/.github/workflows/api-test.yml
+++ b/.github/workflows/api-test.yml
@@ -20,6 +20,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - run: cp .env.example .env
     - run: docker compose up -d --build
     - name: Let Docker Spin up
@@ -51,6 +53,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - run: cp .env.example .env
     # --wait gates on app's depends_on (mongo: service_healthy) to avoid the auth race.
     - run: docker compose --profile mongo up -d --build --wait

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       - name: Run go vet
@@ -37,6 +39,8 @@ jobs:
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@c76cceaaab89abe74e649d2e34c6c9adc26662d2 # v2.7.2
         with:
@@ -54,6 +58,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: reviewdog/action-yamllint@e02a49fdf53f51ddd8dfa89b09aa975043aeba38 # v1.23.0
         with:
           fail_on_error: true
@@ -70,6 +76,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: dotenv-linter/action-dotenv-linter@afde61cfda2ecffe7bea35837b6f20b956c88689 # v3.0.0
         with:
           reporter: github-pr-review
@@ -84,6 +92,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
         with:
           go-version-file: go.mod
@@ -108,6 +118,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Install Dev Container CLI
         run: npm install -g @devcontainers/cli@0.67.0
       - name: Build dev container definition
@@ -142,6 +154,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e
         with:
           go-version: ${{ matrix.go-version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,6 +48,8 @@ jobs:
 
     - name: Checkout repository
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,6 +19,8 @@ jobs:
         egress-policy: audit
 
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
     - name: Build the Docker image
       run: docker build --file Dockerfile --tag  vprodemo.azurecr.io/console:latest --tag vprodemo.azurecr.io/console:${{ github.sha }} .
     - name: Docker Login

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,11 +44,15 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Version
-        run: echo "The next version is ${{ steps.semantic-release.outputs.version }}"
+        env:
+          VERSION: ${{ steps.semantic-release.outputs.version }}
+        run: echo "The next version is $VERSION"
 
       - name: Fail if version is empty
+        env:
+          VERSION: ${{ steps.semantic-release.outputs.version }}
         run: |
-          if [ -z "${{ steps.semantic-release.outputs.version }}" ]; then
+          if [ -z "$VERSION" ]; then
             echo "Version output is empty. Failing the job."
             exit 1
           fi
@@ -56,6 +60,8 @@ jobs:
   build:
     needs: prepare
     runs-on: ubuntu-latest
+    env:
+      VERSION: ${{ needs.prepare.outputs.version }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -70,6 +76,7 @@ jobs:
       - name: Check out Sample Web UI
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: device-management-toolkit/sample-web-ui
           ref: main
           path: ./temp
@@ -93,7 +100,7 @@ jobs:
           go-version: ">=1.23.0"
 
       - name: Version
-        run: echo "The next version is ${{ needs.prepare.outputs.version }}"
+        run: echo "The next version is $VERSION"
 
       - shell: bash
         run: |
@@ -102,28 +109,28 @@ jobs:
       # Cross-compile all platform binaries from a single runner using CGO_ENABLED=0
       # Static Go binaries are cross-platform compatible, so we can build all targets from Linux
       - name: Build Linux x64
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/linux/console_linux_x64 ./cmd/app
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/linux/console_linux_x64 ./cmd/app
 
       - name: Build Linux x64 headless
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/linux/console_linux_x64_headless ./cmd/app
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/linux/console_linux_x64_headless ./cmd/app
 
       - name: Build Linux arm64
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/linux/console_linux_arm64 ./cmd/app
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/linux/console_linux_arm64 ./cmd/app
 
       - name: Build Linux arm64 headless
-        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/linux/console_linux_arm64_headless ./cmd/app
+        run: CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/linux/console_linux_arm64_headless ./cmd/app
 
       - name: Build Windows x64
-        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/windows/console_windows_x64.exe ./cmd/app
+        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/windows/console_windows_x64.exe ./cmd/app
 
       - name: Build Windows x64 headless
-        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/windows/console_windows_x64_headless.exe ./cmd/app
+        run: CGO_ENABLED=0 GOOS=windows GOARCH=amd64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/windows/console_windows_x64_headless.exe ./cmd/app
 
       - name: Build macOS arm64
-        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/darwin/console_mac_arm64 ./cmd/app
+        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/darwin/console_mac_arm64 ./cmd/app
 
       - name: Build macOS arm64 headless
-        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=${{ needs.prepare.outputs.version }}'" -trimpath -o dist/darwin/console_mac_arm64_headless ./cmd/app
+        run: CGO_ENABLED=0 GOOS=darwin GOARCH=arm64 go build -tags=noui -ldflags "-s -w -X 'github.com/device-management-toolkit/console/internal/app.Version=$VERSION'" -trimpath -o dist/darwin/console_mac_arm64_headless ./cmd/app
 
       # Cache all build artifacts in a single step
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -184,6 +191,7 @@ jobs:
       - name: Checkout Sample Web UI for license scan
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           repository: device-management-toolkit/sample-web-ui
           ref: main
           path: ./temp
@@ -262,7 +270,7 @@ jobs:
           API_NAME: ${{ vars.SWAGGERHUB_API_NAME }}
           API_VERSION: ${{ steps.semantic-release.outputs.new_release_version }}
         run: |
-          echo "Pushing OpenAPI spec to SwaggerHub with version ${{ steps.semantic-release.outputs.new_release_version }}..."
+          echo "Pushing OpenAPI spec to SwaggerHub with version ${API_VERSION}..."
           curl -X POST "https://api.swaggerhub.com/apis/${SWAGGERHUB_OWNER}/${API_NAME}/${API_VERSION}" \
             -H "Authorization: ${SWAGGERHUB_API_KEY}" \
             -H "Content-Type: application/json" \

--- a/.github/workflows/semantic.yml
+++ b/.github/workflows/semantic.yml
@@ -17,6 +17,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          persist-credentials: false
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
         with:

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -20,6 +20,8 @@ jobs:
           egress-policy: audit
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
       - name: Build the Docker image
 
         run: docker build . --file Dockerfile --tag app:${{ github.sha }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: (C) 2026 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+---
+# Zizmor configuration. See https://docs.zizmor.sh/configuration/
+rules:
+  # Daily updates with no cooldown are intentional here. A version compromised
+  # at publish time can reach CI before it is yanked, but the blast radius is
+  # small: Dependabot PRs do not receive repository secrets by default and run
+  # with a read-only GITHUB_TOKEN.
+  dependabot-cooldown:
+    ignore:
+      - dependabot.yml


### PR DESCRIPTION
- Set persist-credentials: false on every actions/checkout that does not need the token afterwards (api-test, ci, codeql-analysis, docker-build, semantic, trivy-scan, and the two sample-web-ui checkouts in release).
- Move ${{ ... }} expansions out of run: shells in release.yml into env vars: VERSION for the semantic-release version used by the prepare echo/guard steps and the eight cross-compile ldflags, and the existing API_VERSION for the SwaggerHub push message.
- Add .github/zizmor.yml ignoring dependabot-cooldown, with a note on why daily updates without a cooldown are acceptable here.