### PR TITLE
ci(gh-actions): tighten test gating and drop dead release guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,9 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
+        with:
+          go-version-file: go.mod
       - name: Format
         run: if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then exit 1; fi
       - name: Run go vet
@@ -174,10 +177,11 @@ jobs:
           export GOPATH="$HOME/go/"
           export PATH=$PATH:$GOPATH/bin
           go install github.com/jstemmer/go-junit-report/v2@latest
-          go test -covermode=atomic -coverprofile=coverage.out -race -v ./... > test_output.txt 2>&1 || true
+          test_status=0
+          go test -covermode=atomic -coverprofile=coverage.out -race -v ./... > test_output.txt 2>&1 || test_status=$?
           cat test_output.txt
-          cat test_output.txt | go-junit-report -set-exit-code > junit-${{matrix.os}}-${{matrix.go-version}}-${{github.run_attempt}}.xml
-          if grep -q "FAIL" test_output.txt; then exit 1; fi
+          go-junit-report -set-exit-code < test_output.txt > junit-${{matrix.os}}-${{matrix.go-version}}-${{github.run_attempt}}.xml
+          exit "$test_status"
       - name: Upload Coverage Results
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ jobs:
     outputs:
       version: ${{ steps.semantic-release.outputs.version }}
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
       - name: Checkout Console
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -230,7 +235,6 @@ jobs:
       - name: Semantic Release
         id: semantic-release
         uses: cycjimmy/semantic-release-action@b12c8f6015dc215fe37bc154d4ad456dd3833c90 # v6.0.0
-        if: steps.cache.outputs.cache-hit != 'true' # do not run if cache hit
         with:
           semantic_version:
             19.0.5 # It is recommended to specify a version range


### PR DESCRIPTION
## Summary

Four small robustness fixes to the workflows, found while reviewing a CI/CD
security report. No behaviour change for a passing build.

## Changes

**`ci.yml` — tests job**

`go test` ran with `|| true`, which discards the exit code, and failure was
then inferred by grepping the log for the string `FAIL`. The `|| true` exists
because the JUnit report still has to be written when tests fail. This keeps
that property but captures the real exit code and re-raises it after the
report is generated, so the job status comes from the test run instead of a
string match. Also switches the converter to a redirect rather than
`cat | ...`.

**`ci.yml` — formatting job**

Added `setup-go` pinned to `go.mod`. `gofmt` and `go vet` were running against
whatever Go version the runner image happened to ship. It works today because
Go fetches the toolchain named in `go.mod`, but the version was not pinned the
way it is in the tests job.

**`release.yml` — Semantic Release step**

Removed `if: steps.cache.outputs.cache-hit != 'true'`. No step in the file has
`id: cache`, so the expression always evaluated to empty and the condition
never took effect — releases have always run. Removing it rather than wiring
it up, because skipping the release when the build cache is warm is not the
behaviour we want. Left as is, it would silently start skipping releases the
moment someone adds `id: cache` to one of the two cache steps.

**`release.yml` — prepare job**

Added the `harden-runner` step. This was the only job across all workflows
without it.

## Testing

Exit-code propagation was verified locally for both the passing and failing
paths. Everything else is exercised by this PR's own CI run.

## Note

Not fixed here, to keep the change scoped — the `tests` job declares
`os: [windows-2019, windows-2022, ubuntu-22.04, ubuntu-24.04]` but sets
`runs-on: ubuntu-latest`, so all four legs run on Linux and the two
Windows-named legs never test Windows. One of them is a required status
check. Worth a separate issue, since `windows-2019` runners have been retired
and simply setting `runs-on: ${{ matrix.os }}` would fail.