### PR TITLE
ci(gh-actions): upload trivy sarif as a workflow artifact

### DIFF
--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -40,3 +40,9 @@ jobs:
         if: always()
         with:
           sarif_file: "trivy-results.sarif"
+      - name: Upload Trivy Artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: console-trivy-results.sarif
+          path: console-trivy-results.sarif


### PR DESCRIPTION
The scan already publishes results to the GitHub Security tab, but the raw SARIF was not retained anywhere downloadable. Add an upload-artifact step so the report can be pulled from the run, matching the trivy workflows in rpc-go and sample-web-ui.