### PR TITLE
fix: send nosniff header on all responses

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -2624,7 +2624,9 @@
 				"packages": {},
 				"requests": {},
 				"exec": [
-					""
+					"pm.test(\"Response includes X-Content-Type-Options: nosniff\", function () {",
+					"    pm.expect(pm.response.headers.get(\"X-Content-Type-Options\")).to.eql(\"nosniff\");",
+					"});"
 				]
 			}
 		}

--- a/integration-test/collections/console_rps_apis.postman_collection.json
+++ b/integration-test/collections/console_rps_apis.postman_collection.json
@@ -8419,7 +8419,9 @@
 				"type": "text/javascript",
 				"requests": {},
 				"exec": [
-					""
+					"pm.test(\"Response includes X-Content-Type-Options: nosniff\", function () {",
+					"    pm.expect(pm.response.headers.get(\"X-Content-Type-Options\")).to.eql(\"nosniff\");",
+					"});"
 				]
 			}
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -73,6 +73,9 @@ func setupHTTPHandler(cfg *config.Config, log logger.Interface, usecases *usecas
 	}
 
 	handler := gin.New()
+	// Ahead of CORS on purpose: the CORS middleware answers preflights and
+	// rejects disallowed origins itself, so anything after it never runs.
+	handler.Use(securityHeaders())
 
 	defaultConfig := cors.DefaultConfig()
 	defaultConfig.AllowOrigins = cfg.AllowedOrigins
@@ -98,6 +101,15 @@ func setupHTTPHandler(cfg *config.Config, log logger.Interface, usecases *usecas
 	wsv1.RegisterRoutes(handler, log, usecases.Devices, upgrader)
 
 	return handler
+}
+
+// securityHeaders sets X-Content-Type-Options: nosniff to stop MIME sniffing.
+func securityHeaders() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.Header("X-Content-Type-Options", "nosniff")
+
+		c.Next()
+	}
 }
 
 func setupCIRAServer(cfg *config.Config, log logger.Interface, closer io.Closer, usecases *usecase.Usecases) *cira.Server {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,16 +1,89 @@
-package app_test
+package app
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 
 	"github.com/device-management-toolkit/console/config"
-	"github.com/device-management-toolkit/console/internal/app"
 	"github.com/device-management-toolkit/console/internal/mocks"
+	"github.com/device-management-toolkit/console/internal/usecase"
 	"github.com/device-management-toolkit/console/pkg/logger"
 )
+
+func TestSecurityHeadersSetsNoSniff(t *testing.T) {
+	t.Parallel()
+
+	r := gin.New()
+	r.Use(securityHeaders())
+	r.GET("/ok", func(c *gin.Context) { c.JSON(http.StatusOK, gin.H{"a": 1}) })
+	// SPA fallback, the path the finding was reported against.
+	r.NoRoute(func(c *gin.Context) {
+		c.Data(http.StatusOK, "text/html; charset=utf-8", []byte("<html></html>"))
+	})
+	r.GET("/unauth", func(c *gin.Context) {
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+	})
+
+	for _, path := range []string{"/ok", "/no/such/route", "/unauth"} {
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, httptest.NewRequest(http.MethodGet, path, http.NoBody))
+
+		require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), path)
+	}
+}
+
+// The nosniff middleware has to sit ahead of CORS in the engine chain: the CORS
+// middleware answers preflights and rejects disallowed origins itself, so
+// anything registered after it never runs on those responses.
+//
+//nolint:paralleltest // setupHTTPHandler mutates global gin mode and reads GIN_MODE, which TestRun writes
+func TestSetupHTTPHandlerSetsNoSniffAheadOfCORS(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.AllowedOrigins = []string{"https://allowed.example"}
+	cfg.AllowedHeaders = []string{"Content-Type"}
+	cfg.Disabled = true
+
+	prev := config.ConsoleConfig
+
+	t.Cleanup(func() { config.ConsoleConfig = prev })
+
+	config.ConsoleConfig = cfg
+
+	handler := setupHTTPHandler(cfg, logger.New("error"), &usecase.Usecases{})
+
+	tests := []struct {
+		name      string
+		method    string
+		origin    string
+		preflight bool
+		wantCode  int
+	}{
+		{"CORS rejects a disallowed preflight", http.MethodOptions, "https://blocked.example", true, http.StatusForbidden},
+		{"CORS rejects a disallowed request", http.MethodGet, "https://blocked.example", false, http.StatusForbidden},
+		{"allowed origin reaches the route", http.MethodGet, "https://allowed.example", false, http.StatusOK},
+	}
+
+	for _, tc := range tests {
+		req := httptest.NewRequest(tc.method, "/healthz", http.NoBody)
+		req.Header.Set("Origin", tc.origin)
+
+		if tc.preflight {
+			req.Header.Set("Access-Control-Request-Method", http.MethodGet)
+		}
+
+		w := httptest.NewRecorder()
+		handler.ServeHTTP(w, req)
+
+		require.Equal(t, tc.wantCode, w.Code, tc.name)
+		require.Equal(t, "nosniff", w.Header().Get("X-Content-Type-Options"), tc.name)
+	}
+}
 
 func TestRun(t *testing.T) {
 	t.Parallel()
@@ -24,7 +97,7 @@ func TestRun(t *testing.T) {
 	mockHTTPServer := mocks.NewMockHTTPServer(ctrl)
 
 	cfg, _ := config.NewConfig()
-	cfg.Provider = app.ProviderPostgres
+	cfg.Provider = ProviderPostgres
 	cfg.DB.URL = "postgres://testuser:testpass@localhost/testdb"
 
 	tests := []struct {
@@ -47,7 +120,7 @@ func TestRun(t *testing.T) {
 			cfg: cfg,
 			expectFunc: func(_ *testing.T) {
 				go func() {
-					app.Run(cfg, logger.New("info"))
+					Run(cfg, logger.New("info"))
 				}()
 			},
 		},


### PR DESCRIPTION
Adds middleware ahead of CORS so every response tells the browser to
trust the declared content type. And postman collections check for it.

Response with nosniff: 
curl -sS -g -k --noproxy '*' -D - -o /dev/null "$BASE_URL/healthz"
HTTP/1.1 200 OK
X-Content-Type-Options: nosniff
Date: Tue, 11 Aug 2026 05:13:05 GMT
Content-Length: 0
