### PR TITLE
fix: Add server-side validation for device POST api

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -1728,7 +1728,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n    \"friendlyName\": \"friendlyName\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [],\r\n    \"mpsusername\": \"admin\",\r\n    \"deviceInfo\": {\r\n        \"fwVersion\": \"16.1.30\",\r\n        \"fwBuild\": \"3400\",\r\n        \"fwSku\": \"11\",\r\n        \"discovered\": true,\r\n        \"firstDiscovered\": \"2026-05-20T00:00:00Z\",\r\n        \"currentMode\": \"Admin\",\r\n        \"features\": \"SOL,IDER,KVM\",\r\n        \"ipAddress\": \"10.0.0.12\",\r\n        \"lastSynced\": \"2026-05-21T00:00:00Z\",\r\n        \"tlsMode\": \"TLS 1.2\",\r\n        \"upid\": {\r\n            \"oemPlatformIdType\": \"Not Set (0)\",\r\n            \"oemId\": \"\",\r\n            \"csmeId\": \"4A45A39C5ED9462082510000\"\r\n        },\r\n        \"amtEnabledInBIOS\": true,\r\n        \"meInterfaceVersion\": \"16.1.25.2124\",\r\n        \"dhcpEnabled\": true,\r\n        \"certHashes\": [\r\n            \"a1b2c3\",\r\n            \"d4e5f6\"\r\n        ],\r\n        \"lmsInstalled\": true,\r\n        \"lmsVersion\": \"2410.5.0.0\",\r\n        \"osName\": \"linux\",\r\n        \"osVersion\": \"6.8.0-51-generic\",\r\n        \"osDistro\": \"Ubuntu 24.04 LTS\",\r\n        \"cpuModel\": \"Intel(R) Core(TM) Ultra 7 165H\",\r\n        \"osIpAddress\": \"10.49.76.163\",\r\n        \"ethernetAdapterCount\": 2,\r\n        \"monitorConnected\": true,\r\n        \"ieee8021xEnabled\": false\r\n    }\r\n}",
+							"raw": "{\r\n    \"guid\": \"143e4567-e89b-12d3-a456-426614174000\",\r\n    \"friendlyName\": \"friendlyName\",\r\n    \"hostname\": \"hostname\",\r\n    \"username\": \"admin\",\r\n    \"password\": \"P@ssword123!\",\r\n    \"tags\": [],\r\n    \"mpsusername\": \"admin\",\r\n    \"deviceInfo\": {\r\n        \"fwVersion\": \"16.1.30\",\r\n        \"fwBuild\": \"3400\",\r\n        \"fwSku\": \"11\",\r\n        \"discovered\": true,\r\n        \"firstDiscovered\": \"2026-05-20T00:00:00Z\",\r\n        \"currentMode\": \"Admin\",\r\n        \"features\": \"SOL,IDER,KVM\",\r\n        \"ipAddress\": \"10.0.0.12\",\r\n        \"lastSynced\": \"2026-05-21T00:00:00Z\",\r\n        \"tlsMode\": \"TLS 1.2\",\r\n        \"upid\": {\r\n            \"oemPlatformIdType\": \"Not Set (0)\",\r\n            \"oemId\": \"\",\r\n            \"csmeId\": \"4A45A39C5ED9462082510000\"\r\n        },\r\n        \"amtEnabledInBIOS\": true,\r\n        \"meInterfaceVersion\": \"16.1.25.2124\",\r\n        \"dhcpEnabled\": true,\r\n        \"certHashes\": [\r\n            \"a1b2c3\",\r\n            \"d4e5f6\"\r\n        ],\r\n        \"lmsInstalled\": true,\r\n        \"lmsVersion\": \"2410.5.0.0\",\r\n        \"osName\": \"linux\",\r\n        \"osVersion\": \"6.8.0-51-generic\",\r\n        \"osDistro\": \"Ubuntu 24.04 LTS\",\r\n        \"cpuModel\": \"Intel(R) Core(TM) Ultra 7 165H\",\r\n        \"osIpAddress\": \"10.49.76.163\",\r\n        \"ethernetAdapterCount\": 2,\r\n        \"monitorConnected\": true,\r\n        \"ieee8021xEnabled\": false\r\n    }\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2005,7 +2005,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab6\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [\"ccm\"]\r\n}",
+							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab6\",\r\n    \"hostname\": \"hostname\",\r\n    \"username\": \"admin\",\r\n    \"password\": \"P@ssword123!\",\r\n    \"tags\": [\"ccm\"]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2473,7 +2473,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab7\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [\"acm\"]\r\n}",
+							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab7\",\r\n    \"hostname\": \"hostname\",\r\n    \"username\": \"admin\",\r\n    \"password\": \"P@ssword123!\",\r\n    \"tags\": [\"acm\"]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"

--- a/internal/controller/httpapi/v1/devices.go
+++ b/internal/controller/httpapi/v1/devices.go
@@ -2,6 +2,7 @@ package v1
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 	"strings"
 	"time"
@@ -21,7 +22,12 @@ type deviceRoutes struct {
 	l logger.Interface
 }
 
-var ErrValidationDevices = dto.NotValidError{Console: consoleerrors.CreateConsoleError("ProfileAPI")}
+var (
+	ErrValidationDevices = dto.NotValidError{Console: consoleerrors.CreateConsoleError("ProfileAPI")}
+	ErrHostnameRequired  = errors.New("hostname is required")
+	ErrUsernameRequired  = errors.New("username is required")
+	ErrPasswordRequired  = errors.New("password is required")
+)
 
 func NewDeviceRoutes(handler *gin.RouterGroup, t devices.Feature, l logger.Interface) {
 	r := &deviceRoutes{t, l}
@@ -193,6 +199,24 @@ func (dr *deviceRoutes) insert(c *gin.Context) {
 	if err := c.ShouldBindJSON(&device); err != nil {
 		validationErr := ErrValidationDevices.Wrap("insert", "ShouldBindJSON", err)
 		ErrorResponse(c, validationErr)
+
+		return
+	}
+
+	if strings.TrimSpace(device.Hostname) == "" {
+		ErrorResponse(c, ErrValidationDevices.Wrap("insert", "validate", ErrHostnameRequired))
+
+		return
+	}
+
+	if strings.TrimSpace(device.Username) == "" {
+		ErrorResponse(c, ErrValidationDevices.Wrap("insert", "validate", ErrUsernameRequired))
+
+		return
+	}
+
+	if strings.TrimSpace(device.Password) == "" {
+		ErrorResponse(c, ErrValidationDevices.Wrap("insert", "validate", ErrPasswordRequired))
 
 		return
 	}

--- a/internal/controller/httpapi/v1/devices_test.go
+++ b/internal/controller/httpapi/v1/devices_test.go
@@ -321,6 +321,62 @@ func TestDevicesRoutes(t *testing.T) {
 			response:     dto.DeviceStatResponse{TotalCount: 5},
 			expectedCode: http.StatusOK,
 		},
+		{
+			name:         "insert device - empty hostname",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "", Username: "admin", Password: "password"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - empty username",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "hostname", Username: "", Password: "password"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - empty password",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "hostname", Username: "admin", Password: ""},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - all required fields empty",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - whitespace-only hostname",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "   ", Username: "admin", Password: "password"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - whitespace-only username",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "hostname", Username: "   ", Password: "password"},
+			expectedCode: http.StatusBadRequest,
+		},
+		{
+			name:         "insert device - whitespace-only password",
+			method:       http.MethodPost,
+			url:          "/api/v1/devices",
+			mock:         func(_ *mocks.MockDeviceManagementFeature) {},
+			requestBody:  dto.Device{Hostname: "hostname", Username: "admin", Password: "   "},
+			expectedCode: http.StatusBadRequest,
+		},
 	}
 
 	for _, tc := range tests {
@@ -527,6 +583,8 @@ func TestDevicesInsertAcceptsFullDeviceInfo(t *testing.T) {
 	incoming := &dto.Device{
 		GUID:     testDeviceGUID,
 		Hostname: "test-device",
+		Username: "admin",
+		Password: "password",
 		DeviceInfo: &dto.DeviceInfo{
 			FWVersion:       "16.1.30",
 			FWBuild:         "3400",
@@ -569,6 +627,8 @@ func TestDevicesInsertAcceptsFullDeviceInfo(t *testing.T) {
 	body := []byte(`{
 		"guid":"` + testDeviceGUID + `",
 		"hostname":"test-device",
+		"username":"admin",
+		"password":"password",
 		"deviceInfo":{
 			"fwVersion":"16.1.30",
 			"fwBuild":"3400",


### PR DESCRIPTION
- Add explicit server-side checks in the insert handler that return 400 Bad Request when hostname, username, or password is absent
- With this change POST /api/v1/devices will not accept requests with empty hostname, username, and password

** POST /api/v1/devices Behaviour before changes:-**
```
$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H "Content-Type: application/json"   -d '{
    "hostname": "device",
    "friendlyName": "device",
    "username": "device",
    "password": "",
    "tenantId": "",
    "useTLS": false,
    "allowSelfSigned": false,
    "guid": "",
    "tags": []
  }' | jq .
{
  "connectionStatus": false,
  "mpsInstance": "",
  "hostname": "device",
  "guid": "2f7b265d-a940-40eb-b3f3-c26625d62f2a",
  "mpsusername": "",
  "tags": [],
  "tenantId": "",
  "friendlyName": "device",
  "dnsSuffix": "",
  "username": "device",
  "password": "",
  "mpspassword": "",
  "mebxpassword": "",
  "useTLS": false,
  "allowSelfSigned": false,
  "certHash": ""
}
```

** POST /api/v1/devices Behaviour after changes:**

```
$ curl -sk -X POST https://localhost:8181/api/v1/devices \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -d '{
    "hostname": "",
    "friendlyName": "",
    "username": "",
    "password": "",
    "tenantId": "",
    "useTLS": false,
    "allowSelfSigned": false,
    "guid": "",
    "tags": []
  }' | jq .
{
  "error": "Invalid input: hostname is required",
  "message": "Invalid input: hostname is required"
}

$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H "Content-Type: application/json"   -d '{
    "hostname": "random-hostname",
    "friendlyName": "",
    "username": "",
    "password": "",
    "tenantId": "",
    "useTLS": false,
    "allowSelfSigned": false,
    "guid": "",
    "tags": []
  }' | jq .
{
  "error": "Invalid input: username is required",
  "message": "Invalid input: username is required"
}

$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H "Content-Type: application/json"   -d '{
    "hostname": "random-hostname",
    "friendlyName": "",
    "username": "random-username",
    "password": "",
    "tenantId": "",
    "useTLS": false,
    "allowSelfSigned": false,
    "guid": "",
    "tags": []
  }' | jq .
{
  "error": "Invalid input: password is required",
  "message": "Invalid input: password is required"
}

```