### PR TITLE
fix: Reject duplicate device hostnames with 409

### DIFF
--- a/integration-test/collections/console_mps_apis.postman_collection.json
+++ b/integration-test/collections/console_mps_apis.postman_collection.json
@@ -1751,6 +1751,53 @@
 					"response": []
 				},
 				{
+					"name": "Create Device - Duplicate Hostname",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 409\", function () {\r",
+									"    pm.response.to.have.status(409);\r",
+									"});\r",
+									"pm.test(\"Expect conflict error\", function () {\r",
+									"    var jsonData = pm.response.json();\r",
+									"    pm.expect(jsonData.error).to.include(\"resource already exists\");\r",
+									"})"
+								],
+								"type": "text/javascript",
+								"packages": {}
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": []\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/devices",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"devices"
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "Device by GUID",
 					"event": [
 						{
@@ -1989,7 +2036,7 @@
 									"pm.test(\"Expect to return device info\",function(){\r",
 									"    var jsonData = pm.response.json();\r",
 									"    pm.expect(jsonData.guid).to.be.equal(\"d12428be-9fa1-4226-9784-54b2038beab6\")\r",
-									"    pm.expect(jsonData.hostname).to.be.equal(\"hostname\")\r",
+									"    pm.expect(jsonData.hostname).to.be.equal(\"hostname2\")\r",
 									"    pm.expect(jsonData.tags.length).to.be.equal(1)  \r",
 									"    pm.expect(jsonData.mpsInstance).to.be.equal(\"\")\r",
 									"    pm.expect(jsonData.connectionStatus).to.be.equal(false)\r",
@@ -2005,7 +2052,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab6\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [\"ccm\"]\r\n}",
+							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab6\",\r\n    \"hostname\": \"hostname2\",\r\n    \"tags\": [\"ccm\"]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2457,7 +2504,7 @@
 									"pm.test(\"Expect to return device info\",function(){\r",
 									"    var jsonData = pm.response.json();\r",
 									"    pm.expect(jsonData.guid).to.be.equal(\"d12428be-9fa1-4226-9784-54b2038beab7\")\r",
-									"    pm.expect(jsonData.hostname).to.be.equal(\"hostname\")\r",
+									"    pm.expect(jsonData.hostname).to.be.equal(\"hostname3\")\r",
 									"    pm.expect(jsonData.tags.length).to.be.equal(1)  \r",
 									"    pm.expect(jsonData.mpsInstance).to.be.equal(\"\")\r",
 									"    pm.expect(jsonData.connectionStatus).to.be.equal(false)\r",
@@ -2473,7 +2520,7 @@
 						"header": [],
 						"body": {
 							"mode": "raw",
-							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab7\",\r\n    \"hostname\": \"hostname\",\r\n    \"tags\": [\"acm\"]\r\n}",
+							"raw": "{\r\n    \"guid\": \"d12428be-9fa1-4226-9784-54b2038beab7\",\r\n    \"hostname\": \"hostname3\",\r\n    \"tags\": [\"acm\"]\r\n}",
 							"options": {
 								"raw": {
 									"language": "json"
@@ -2597,6 +2644,40 @@
 								"v1",
 								"devices",
 								"d12428be-9fa1-4226-9784-54b2038beab6"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Device",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"exec": [
+									"pm.test(\"Status code is 204\", function () {\r",
+									"    pm.response.to.have.status(204);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{protocol}}://{{host}}/api/v1/devices/d12428be-9fa1-4226-9784-54b2038beab7",
+							"protocol": "{{protocol}}",
+							"host": [
+								"{{host}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"devices",
+								"d12428be-9fa1-4226-9784-54b2038beab7"
 							]
 						}
 					},

--- a/internal/usecase/devices/repo.go
+++ b/internal/usecase/devices/repo.go
@@ -17,6 +17,7 @@ var (
 	ErrDeviceUseCase = consoleerrors.CreateConsoleError("DevicesUseCase")
 	ErrDatabase      = repoerrors.DatabaseError{Console: ErrDeviceUseCase}
 	ErrNotFound      = repoerrors.NotFoundError{Console: ErrDeviceUseCase}
+	ErrNotUnique     = repoerrors.NotUniqueError{Console: ErrDeviceUseCase}
 	ErrCancelled     = dto.CanceledError{Console: ErrDeviceUseCase}
 )
 
@@ -245,6 +246,17 @@ func (uc *UseCase) Insert(ctx context.Context, d *dto.Device) (*dto.Device, erro
 	d1, err := uc.dtoToEntity(d)
 	if err != nil {
 		return nil, err
+	}
+
+	if d1.Hostname != "" {
+		existing, err := uc.repo.GetByColumn(ctx, "hostname", d1.Hostname, d1.TenantID)
+		if err != nil {
+			return nil, ErrDatabase.Wrap("Insert", "uc.repo.GetByColumn", err)
+		}
+
+		if len(existing) > 0 {
+			return nil, ErrNotUnique
+		}
 	}
 
 	if d1.GUID == "" {

--- a/internal/usecase/devices/repo_test.go
+++ b/internal/usecase/devices/repo_test.go
@@ -447,6 +447,55 @@ func TestInsert(t *testing.T) {
 	}
 }
 
+func TestInsert_HostnameConflict(t *testing.T) {
+	t.Parallel()
+
+	t.Run("insertion fails - hostname already exists", func(t *testing.T) {
+		t.Parallel()
+
+		useCase, repo, _ := devicesTest(t)
+
+		repo.EXPECT().
+			GetByColumn(context.Background(), "hostname", "test-hostname", "tenant-id-456").
+			Return([]entity.Device{{GUID: "existing-guid", Hostname: "test-hostname", TenantID: "tenant-id-456"}}, nil)
+
+		deviceDTO := &dto.Device{
+			Hostname: "test-hostname",
+			TenantID: "tenant-id-456",
+			Tags:     []string{},
+		}
+
+		result, err := useCase.Insert(context.Background(), deviceDTO)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+
+		var notUnique repoerrors.NotUniqueError
+		require.ErrorAs(t, err, &notUnique)
+	})
+
+	t.Run("insertion fails - hostname lookup db error", func(t *testing.T) {
+		t.Parallel()
+
+		useCase, repo, _ := devicesTest(t)
+
+		repo.EXPECT().
+			GetByColumn(context.Background(), "hostname", "test-hostname", "tenant-id-456").
+			Return(nil, devices.ErrDatabase)
+
+		deviceDTO := &dto.Device{
+			Hostname: "test-hostname",
+			TenantID: "tenant-id-456",
+			Tags:     []string{},
+		}
+
+		result, err := useCase.Insert(context.Background(), deviceDTO)
+
+		require.Error(t, err)
+		require.Nil(t, result)
+	})
+}
+
 func TestUpdateWithPasswords(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
POST /api/v1/devices now checks whether a device with the same hostname already exists before inserting.
If a duplicate is found, the endpoint returns 409 Conflict("resource already exists") instead of silently creating a second record with a new GUID.

**Before Fix:**
```
$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H 'Content-Type: application/json'   -d '{"hostname":"testdevice","username":"admin","password":"P@ssw0rd","useTLS":false,"allowSelfSigned":false,"tags":[]}'
{"connectionStatus":false,"mpsInstance":"","hostname":"testdevice","guid":"8c443da5-38ff-4e15-a2bb-692b0d01f632","mpsusername":"","tags":[],"tenantId":"","friendlyName":"","dnsSuffix":"","username":"admin","password":"","mpspassword":"","mebxpassword":"","useTLS":false,"allowSelfSigned":false,"certHash":""}

$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H 'Content-Type: application/json'   -d '{"hostname":"testdevice","username":"admin","password":"P@ssw0rd","useTLS":false,"allowSelfSigned":false,"tags":[]}'
{"connectionStatus":false,"mpsInstance":"","hostname":"testdevice","guid":"c6a62438-80f5-4140-aa1d-e4084f6632f2","mpsusername":"","tags":[],"tenantId":"","friendlyName":"","dnsSuffix":"","username":"admin","password":"","mpspassword":"","mebxpassword":"","useTLS":false,"allowSelfSigned":false,"certHash":""}
```

**After fix:**
```
$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H 'Content-Type: application/json'   -d '{"hostname":"testdevice","username":"admin","password":"P@ssw0rd","useTLS":false,"allowSelfSigned":false,"tags":[]}'
{"connectionStatus":false,"mpsInstance":"","hostname":"testdevice","guid":"71addbf1-455a-4b95-85b0-ea95f06bd90f","mpsusername":"","tags":[],"tenantId":"","friendlyName":"","dnsSuffix":"","username":"admin","password":"","mpspassword":"","mebxpassword":"","useTLS":false,"allowSelfSigned":false,"certHash":""}

$ curl -sk -X POST https://localhost:8181/api/v1/devices   -H "Authorization: Bearer $TOKEN"   -H 'Content-Type: application/json'   -d '{"hostname":"testdevice","username":"admin","password":"P@ssw0rd","useTLS":false,"allowSelfSigned":false,"tags":[]}'
{"error":"unique constraint violation: hostname already exists","message":"unique constraint violation: hostname already exists"}
```