### PR TITLE
refactor(db): parse DSN when defaulting postgres sslmode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,10 @@ SECRET_TOKEN=
 # Database
 DB_POOL_MAX=2
 DB_PROVIDER=
+# Postgres TLS settings come from the DSN. Console defaults sslmode=disable only
+# when sslmode isn't set (so local/compose plaintext works); schema migrations and
+# the runtime connection pool resolve the DSN identically.
+# In production, set sslmode=verify-full (and sslrootcert) explicitly.
 DB_URL=
 
 # EA

--- a/Makefile
+++ b/Makefile
@@ -141,8 +141,20 @@ migrate-create:  ### create new migration
 	migrate create -ext sql -dir /internal/app/migrations 'migrate_name'
 .PHONY: migrate-create
 
+# Mirror pkg/db.NormalizeDSN: default sslmode=disable only when DB_URL doesn't
+# set one, using the right separator for a DSN that already carries query params.
+ifeq (,$(DB_URL))
+MIGRATE_DB_URL :=
+else ifneq (,$(findstring sslmode=,$(DB_URL)))
+MIGRATE_DB_URL := $(DB_URL)
+else ifeq (,$(findstring ?,$(DB_URL)))
+MIGRATE_DB_URL := $(DB_URL)?sslmode=disable
+else
+MIGRATE_DB_URL := $(DB_URL)&sslmode=disable
+endif
+
 migrate-up: ### migration up
-	migrate -path /internal/app/migrations -database '$(DB_URL)?sslmode=disable' up
+	migrate -path /internal/app/migrations -database '$(MIGRATE_DB_URL)' up
 .PHONY: migrate-up
 
 bin-deps:

--- a/internal/app/migrate.go
+++ b/internal/app/migrate.go
@@ -21,6 +21,7 @@ import (
 	_ "modernc.org/sqlite" // sqlite3 driver
 
 	"github.com/device-management-toolkit/console/config"
+	"github.com/device-management-toolkit/console/pkg/db"
 )
 
 const (
@@ -55,7 +56,7 @@ func Init(cfg *config.Config) error {
 		log.Fatal(err)
 	}
 
-	if strings.HasPrefix(databaseURL, "postgres://") {
+	if strings.HasPrefix(databaseURL, db.PostgresPrefix) {
 		err := setupHostedDB(migrationsSource, databaseURL)
 		if err != nil {
 			return err
@@ -87,18 +88,18 @@ func setupLocalDB(migrationsSource source.Driver) error {
 
 	log.Printf("DB path : %s\n", filepath.Join(consoleDir, "console.db"))
 
-	db, err := sql.Open("sqlite", filepath.Join(consoleDir, "console.db"))
+	sqlDB, err := sql.Open("sqlite", filepath.Join(consoleDir, "console.db"))
 	if err != nil {
 		return err
 	}
 
 	defer func() {
-		if err1 := db.Close(); err1 != nil {
+		if err1 := sqlDB.Close(); err1 != nil {
 			return
 		}
 	}()
 
-	driver, err := dbdbdb.WithInstance(db, &dbdbdb.Config{})
+	driver, err := dbdbdb.WithInstance(sqlDB, &dbdbdb.Config{})
 	if err != nil {
 		return err
 	}
@@ -115,7 +116,7 @@ func setupLocalDB(migrationsSource source.Driver) error {
 		}
 	}
 
-	_, err = db.ExecContext(context.Background(), "PRAGMA foreign_keys = ON")
+	_, err = sqlDB.ExecContext(context.Background(), "PRAGMA foreign_keys = ON")
 	if err != nil {
 		return err
 	}
@@ -126,7 +127,9 @@ func setupLocalDB(migrationsSource source.Driver) error {
 }
 
 func setupHostedDB(migrationsSource source.Driver, databaseURL string) error {
-	databaseURL += "?sslmode=disable"
+	// Share the runtime pool's DSN normalization so migrations and queries
+	// agree on sslmode instead of splitting on their drivers' own defaults.
+	databaseURL = db.NormalizeDSN(databaseURL)
 
 	var (
 		attempts = _defaultAttempts

--- a/pkg/db/dsn.go
+++ b/pkg/db/dsn.go
@@ -1,0 +1,34 @@
+package db
+
+import (
+	"net/url"
+	"strings"
+)
+
+// PostgresPrefix is the DSN scheme that routes to the hosted Postgres path.
+const PostgresPrefix = "postgres://"
+
+// NormalizeDSN defaults sslmode to "disable" only when a Postgres DSN doesn't
+// set one, so the migration driver (lib/pq, which defaults to require) and the
+// runtime pool (pgx, which defaults to prefer) resolve the same URL to the same
+// TLS behavior. Non-Postgres DSNs are returned untouched.
+func NormalizeDSN(dsn string) string {
+	if !strings.HasPrefix(dsn, PostgresPrefix) {
+		return dsn
+	}
+
+	parsed, err := url.Parse(dsn)
+	if err != nil {
+		return dsn // let the driver report the malformed DSN
+	}
+
+	query := parsed.Query()
+	if query.Has("sslmode") {
+		return dsn
+	}
+
+	query.Set("sslmode", "disable")
+	parsed.RawQuery = query.Encode()
+
+	return parsed.String()
+}

--- a/pkg/db/dsn_test.go
+++ b/pkg/db/dsn_test.go
@@ -1,0 +1,62 @@
+package db
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeDSN(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "no query string defaults to disable",
+			url:      "postgres://user:pass@localhost:5432/rpsdb",
+			expected: "postgres://user:pass@localhost:5432/rpsdb?sslmode=disable",
+		},
+		{
+			name:     "explicit sslmode is preserved",
+			url:      "postgres://user:pass@localhost:5432/rpsdb?sslmode=verify-full",
+			expected: "postgres://user:pass@localhost:5432/rpsdb?sslmode=verify-full",
+		},
+		{
+			name:     "explicit sslmode with sslrootcert is preserved",
+			url:      "postgres://user:pass@db.example.com:5432/rpsdb?sslmode=verify-full&sslrootcert=%2Fetc%2Fssl%2Fca.pem",
+			expected: "postgres://user:pass@db.example.com:5432/rpsdb?sslmode=verify-full&sslrootcert=%2Fetc%2Fssl%2Fca.pem",
+		},
+		{
+			name:     "existing query without sslmode keeps its params",
+			url:      "postgres://user:pass@localhost:5432/rpsdb?connect_timeout=5",
+			expected: "postgres://user:pass@localhost:5432/rpsdb?connect_timeout=5&sslmode=disable",
+		},
+		{
+			name:     "malformed url is passed through untouched",
+			url:      "postgres://user:pass@local host:5432/rpsdb",
+			expected: "postgres://user:pass@local host:5432/rpsdb",
+		},
+		{
+			name:     "non-postgres dsn is passed through untouched",
+			url:      "mongodb://mongoadmin:admin123@localhost:27017/?authSource=admin",
+			expected: "mongodb://mongoadmin:admin123@localhost:27017/?authSource=admin",
+		},
+		{
+			name:     "empty dsn is passed through untouched",
+			url:      "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tt.expected, NormalizeDSN(tt.url))
+		})
+	}
+}

--- a/pkg/db/sql.go
+++ b/pkg/db/sql.go
@@ -56,7 +56,7 @@ func New(url string, dbOpen OpenFunc, opts ...Option) (*SQL, error) {
 
 	var err error
 
-	if strings.HasPrefix(url, "postgres://") {
+	if strings.HasPrefix(url, PostgresPrefix) {
 		err = setupHostedDB(db, url, dbOpen)
 		if err != nil {
 			return nil, err
@@ -114,7 +114,7 @@ func enableForeignKeys(db *sql.DB) error {
 func setupHostedDB(db *SQL, url string, dbOpen OpenFunc) error {
 	var err error
 
-	db.Pool, err = dbOpen("pgx", url)
+	db.Pool, err = dbOpen("pgx", NormalizeDSN(url))
 	if err != nil {
 		return err
 	}

--- a/pkg/db/sql_test.go
+++ b/pkg/db/sql_test.go
@@ -30,7 +30,8 @@ func TestNew_Postgres(t *testing.T) {
 	t.Parallel()
 
 	mockDB := new(MockDB)
-	mockDB.On("Open", "pgx", "postgres://localhost:5432/testdb").Return(&sql.DB{}, nil)
+	// The pool receives the same normalized DSN the migrations run against.
+	mockDB.On("Open", "pgx", "postgres://localhost:5432/testdb?sslmode=disable").Return(&sql.DB{}, nil)
 
 	db, err := New("postgres://localhost:5432/testdb", mockDB.Open)
 	assert.NoError(t, err)
@@ -39,6 +40,22 @@ func TestNew_Postgres(t *testing.T) {
 	assert.Equal(t, _defaultMaxPoolSize, db.maxPoolSize)
 	assert.Equal(t, _defaultConnAttempts, db.connAttempts)
 	assert.Equal(t, _defaultConnTimeout, db.connTimeout)
+
+	mockDB.AssertExpectations(t)
+}
+
+func TestNew_PostgresPreservesExplicitSSLMode(t *testing.T) {
+	t.Parallel()
+
+	dsn := "postgres://localhost:5432/testdb?sslmode=verify-full&sslrootcert=%2Fetc%2Fssl%2Fca.pem"
+
+	mockDB := new(MockDB)
+	mockDB.On("Open", "pgx", dsn).Return(&sql.DB{}, nil)
+
+	db, err := New(dsn, mockDB.Open)
+	assert.NoError(t, err)
+	assert.NotNil(t, db)
+	assert.False(t, db.IsEmbedded)
 
 	mockDB.AssertExpectations(t)
 }


### PR DESCRIPTION
setupHostedDB concatenated "?sslmode=disable" onto DB_URL, which forced plaintext for schema migrations and produced a malformed DSN when the URL already carried a query string.

Parse the DSN(Data Source Name) and only default sslmode when the operator hasn't set one, so verify-full and sslrootcert pass through untouched while the plaintext dev/compose Postgres keeps working.